### PR TITLE
Update MTBench to support wandb.Artifact models and ensure explicit G…

### DIFF
--- a/scripts/cleanup.py
+++ b/scripts/cleanup.py
@@ -1,0 +1,14 @@
+import gc
+import torch
+
+def cleanup_gpu():
+    """
+    Function to clean up GPU memory
+    """
+    # Remove references to all CUDA objects
+    for obj in gc.get_objects():
+        if torch.is_tensor(obj) and obj.is_cuda:
+            del obj
+    gc.collect()
+    torch.cuda.empty_cache()
+    print(torch.cuda.memory_summary())

--- a/scripts/mtbench_eval.py
+++ b/scripts/mtbench_eval.py
@@ -66,6 +66,23 @@ def mtbench_evaluate():
     else:
         ref_answer_dir = run.use_artifact(cfg.mtbench.referenceanswer_artifacts_path, type='dataset').download()
 
+    # Download and move both tokenizer and model artifacts to a new folder, then set the new folder name as model_path
+    import os
+    import shutil
+
+    # Only create a new folder and use it as model_path for model and tokenizer if we are using artifacts
+    import os
+    import shutil
+
+    # Tokenizer artifactをダウンロード
+    if cfg.model.use_wandb_artifacts:
+        artifact_tokenizer = run.use_artifact(cfg.tokenizer.artifacts_path)
+        tokenizer_path = artifact_tokenizer.download()
+        artifact_model = run.use_artifact(cfg.model.artifacts_path)
+        model_path = artifact_model.download()
+
+        cfg.model.pretrained_model_name_or_path = model_path
+    
     # 1. generate model answers
     if cfg.api in ["openai","anthropic","cohere","google","amazon_bedrock","mistral"]:
         questions = load_questions(question_file, None, None)

--- a/scripts/run_eval.py
+++ b/scripts/run_eval.py
@@ -1,13 +1,15 @@
 import wandb
 from wandb.sdk.wandb_run import Run
+import os
 import sys
-from omegaconf import OmegaConf
+from omegaconf import DictConfig, OmegaConf
 import pandas as pd
 sys.path.append('llm-jp-eval/src') 
 sys.path.append('FastChat')
 from llm_jp_eval.evaluator import evaluate
 from mtbench_eval import mtbench_evaluate
 from config_singleton import WandbConfigSingleton
+from cleanup import cleanup_gpu
 
 # Configuration loading
 cfg = OmegaConf.load("configs/config.yaml")
@@ -24,11 +26,6 @@ if cfg.wandb.log:
         config=cfg_dict,
         job_type="evaluation",
     )
-    
-    # Save configuration as artifact
-    artifact = wandb.Artifact('config', type='config')
-    artifact.add_file("configs/config.yaml")
-    run.log_artifact(artifact)
 else:
     run = None
     run_name = "Nan"
@@ -36,12 +33,30 @@ else:
 # Initialize the WandbConfigSingleton
 WandbConfigSingleton.initialize(run, wandb.Table(dataframe=pd.DataFrame()))
 
+# Save configuration as artifact
+if cfg.wandb.log:
+    if os.path.exists("configs/config.yaml"):
+        artifact_config_path = "configs/config.yaml"
+    else:
+        # If "configs/config.yaml" does not exist, write the contents of run.config as a YAML configuration string
+        instance = WandbConfigSingleton.get_instance()
+        assert isinstance(instance.config, DictConfig), "instance.config must be a DictConfig"
+        with open("configs/config.yaml", 'w') as f:
+            f.write(OmegaConf.to_yaml(instance.config))
+        artifact_config_path = "configs/config.yaml"
+
+    artifact = wandb.Artifact('config', type='config')
+    artifact.add_file(artifact_config_path)
+    run.log_artifact(artifact)
+
 # Evaluation phase
 # 1. llm-jp-eval evaluation
 evaluate()
+cleanup_gpu()
 
 # 2. mt-bench evaluation
 mtbench_evaluate()
+cleanup_gpu()
 
 # Logging results to W&B
 if cfg.wandb.log and run is not None:


### PR DESCRIPTION
…PU memory release after each evaluation.

This commit includes:
- Adaptation of MTBench evaluation scripts to work with models stored as wandb.Artifacts.
- Modifications to the evaluation process to explicitly release GPU memory after each evaluation metric is computed.

The changes aim to improve the integration with wandb and enhance resource management during evaluations.