### PR TITLE
Add cfg.mtbench.use_azure

### DIFF
--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -59,6 +59,7 @@ mtbench:
   num_gpus_total: 1
   max_gpu_memory: null
   dtype: bfloat16 # None or float32 or float16 or bfloat16
+  use_azure: false
   # for conv template # added
   custom_conv_template: false
   # the following variables will be used when custom_conv_template is set as true

--- a/scripts/mtbench_eval.py
+++ b/scripts/mtbench_eval.py
@@ -196,11 +196,11 @@ def mtbench_evaluate(language):
     # Play matches
     if cfg.mtbench.parallel == 1:
         for match in tqdm(matches):
-            play_a_match_func(match, output_file=output_file)
+            play_a_match_func(match, output_file=output_file, use_azure=cfg.mtbench.use_azure)
     else:
 
         def play_a_match_wrapper(match):
-            play_a_match_func(match, output_file=output_file)
+            play_a_match_func(match, output_file=output_file, use_azure=cfg.mtbench.use_azure)
 
         np.random.seed(0)
         np.random.shuffle(matches)


### PR DESCRIPTION
Adds `cfg.mtbench.use_azure` config entry in order to use Azure OpenAI Service in MT bench.

This PR requires a fix to FastChat:  https://github.com/wandb/FastChat/pull/25
