### PR TITLE
Add mtbech parallelization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ configs/config.yaml
 # debug
 dataset/
 logs/
+fastchat/llm_judge/data/japanese_mt_bench

--- a/configs/config_prototype.yaml
+++ b/configs/config_prototype.yaml
@@ -60,7 +60,7 @@ mtbench:
   judge_model: 'gpt-4o-2024-05-13'
   mode: 'single'
   baseline_model: null 
-  parallel: 1
+  parallel: 40
   first_n: null
 
 

--- a/scripts/fastchat/llm_judge/common.py
+++ b/scripts/fastchat/llm_judge/common.py
@@ -225,11 +225,6 @@ def play_a_match_single(match: MatchSingle, output_file: str):
             "turn": turn,
             "tstamp": time.time(),
         }
-        print(
-            f"question: {question_id}, turn: {turn}, model: {model}, "
-            f"score: {score}, "
-            f"judge: {(judge.model_name, judge.prompt_template['name'])}"
-        )
     else:
         raise ValueError(f"invalid judge type: {judge['type']}")
 

--- a/scripts/mtbench_eval.py
+++ b/scripts/mtbench_eval.py
@@ -21,12 +21,16 @@ from fastchat.conversation import initialize_vllm_custom_template
 from config_singleton import WandbConfigSingleton
 
 def mtbench_evaluate():
+    print("Debug: Start mtbench_evaluate")
+    
     # Retrieve the instance from WandbConfigSingleton and load the W&B run and configuration
+    print("Debug: Retrieve WandbConfigSingleton instance")
     instance = WandbConfigSingleton.get_instance()
     run = instance.run
     cfg = instance.config
     
     # create hash and append it to the model_id in order to avoid duplicated id
+    print("Debug: Create hash and append to model_id")
     mnaum_data = str(datetime.datetime.now())
     encoded_data = mnaum_data.encode()
     hash_object = hashlib.sha256(encoded_data)
@@ -34,28 +38,31 @@ def mtbench_evaluate():
     if cfg.mtbench.model_id == None:
         cfg.mtbench.model_id = f'{cfg.model.pretrained_model_name_or_path.replace("/", "--")}_hash_{hashed_string}' 
 
-    if cfg.api=='vllm':
+    if cfg.api == 'vllm':
+        print("Debug: Initialize vllm custom template")
         initialize_vllm_custom_template()
 
     if cfg.mtbench.num_gpus_total // cfg.mtbench.num_gpus_per_model > 1:
+        print("Debug: Initialize ray")
         import ray
         ray.init()
     
     ## file path
     #question
+    print("Debug: Determine artifact directory")
     if cfg.testmode:
         artifact_dir = run.use_artifact(cfg.mtbench.question_artifacts_path_test, type='dataset').download()
     else:
         artifact_dir = run.use_artifact(cfg.mtbench.question_artifacts_path, type='dataset').download()
-    question_file = artifact_dir+f"/question.jsonl"
+    question_file = artifact_dir + f"/question.jsonl"
     
     #create answerfile and answerdir
+    print("Debug: Create answer file and directory")
     answer_file = f"fastchat/llm_judge/data/{cfg.mtbench.bench_name}/model_answer/{cfg.mtbench.model_id}.jsonl"
-    answer_dir = (
-        f"fastchat/llm_judge/data/{cfg.mtbench.bench_name}/model_answer"
-    )
+    answer_dir = f"fastchat/llm_judge/data/{cfg.mtbench.bench_name}/model_answer"
 
-    #refeerence answer
+    #reference answer
+    print("Debug: Determine reference answer directory")
     if cfg.testmode:
         ref_answer_dir = run.use_artifact(cfg.mtbench.referenceanswer_artifacts_path_test, type='dataset').download()
     else:
@@ -63,23 +70,25 @@ def mtbench_evaluate():
 
     
     # 1. generate model answers
+    print("Debug: Generate model answers")
     if cfg.api in ["openai","anthropic","cohere","google","amazon_bedrock","mistral", "vllm"]:
         questions = load_questions(question_file, None, None)
         get_api_answer(
             question_file=question_file,
-            answer_file=answer_file
+            answer_file=answer_file,
+            num_worker=cfg.mtbench.parallel,
         )
 
     # 2. evaluate outputs
-    ## Load questions
+    print("Debug: Evaluate outputs - Load questions")
     questions = load_questions(question_file, None, None)
 
-    ## Load answers
+    print("Debug: Evaluate outputs - Load model answers")
     model_answers = load_model_answers(answer_dir)
     model_answers = {cfg.mtbench.model_id: model_answers[cfg.mtbench.model_id]}
     ref_answers = load_model_answers(ref_answer_dir)
 
-    ## Load judge
+    print("Debug: Evaluate outputs - Load judge prompts")
     artifact_dir = run.use_artifact(cfg.mtbench.judge_prompt_artifacts_path, type='dataset').download()
     judge_prompts = load_judge_prompts(artifact_dir + "/judge_prompts.jsonl")
 
@@ -89,11 +98,10 @@ def mtbench_evaluate():
     models = [cfg.mtbench.model_id] #get_model_list(answer_dir)
  
     #if cfg.mtbench.mode == "single":
+    print("Debug: Evaluate outputs - Make judges and matches")
     judges = make_judge_single(cfg.mtbench.judge_model, judge_prompts)
     play_a_match_func = play_a_match_single
-    output_file = (
-        f"fastchat/llm_judge/data/{cfg.mtbench.bench_name}/model_judgment/{cfg.mtbench.judge_model}_single"
-    )
+    output_file = f"fastchat/llm_judge/data/{cfg.mtbench.bench_name}/model_judgment/{cfg.mtbench.judge_model}_single"
     make_match_func = make_match_single
     baseline_model = None
 
@@ -103,6 +111,7 @@ def mtbench_evaluate():
     question_default = [q for q in questions if q["category"] not in NEED_REF_CATS]
 
     # Make matches
+    print("Debug: Make matches")
     matches = []
     matches += make_match_func(
         question_default, models, model_answers, judges["default"], baseline_model
@@ -147,37 +156,39 @@ def mtbench_evaluate():
     match_stat["output_path"] = output_file
 
     # Show match stats and prompt enter to continue
+    print("Debug: Show match stats and prompt enter to continue")
     print("Stats:")
     print(json.dumps(match_stat, indent=4))
     #input("Press Enter to confirm...")
 
     # Play matches
+    import concurrent.futures
+    from tqdm import tqdm
+    print("Debug: Play matches")
     if cfg.mtbench.parallel == 1:
-        for match in tqdm(matches):
+        for match in tqdm.tqdm(matches):
             play_a_match_func(match, output_file=output_file)
     else:
-
         def play_a_match_wrapper(match):
             play_a_match_func(match, output_file=output_file)
 
         np.random.seed(0)
         np.random.shuffle(matches)
 
-        with ThreadPoolExecutor(cfg.mtbench.parallel) as executor:
-            for match in tqdm(
-                executor.map(play_a_match_wrapper, matches), total=len(matches)
-            ):
-                pass
+        with concurrent.futures.ThreadPoolExecutor(max_workers=cfg.mtbench.parallel) as executor:
+            futures = [executor.submit(play_a_match_wrapper, match) for match in matches]
+            for future in tqdm(concurrent.futures.as_completed(futures), total=len(futures)):
+                try:
+                    future.result()
+                except Exception as e:
+                    print(f"Function raised an exception: {e}")
 
     # 3. consolidate results and log as wandb.Table
+    print("Debug: Consolidate results and log as wandb.Table")
     # load questions
     df_question = pd.read_json(question_file, lines=True)
     df_question_repeat = df_question.loc[df_question.index.repeat(judge_count)].reset_index(drop=True)
     # load answers
-    # Reason of using [df_answer.model_id == cfg.mtbench.model_id| (df_answer.model_id == cfg.model.pretrained_model_name_or_path
-    # The answer files generated through the API use the model name as the model ID. 
-    # However, for the answer files created by our local model implementation, the model ID is used as the model ID. 
-    # It will be necessary to make changes in the future to standardize this.
     df_answer = pd.read_json(answer_file, lines=True)
     df_answer = df_answer[(df_answer.model_id == cfg.mtbench.model_id)|(df_answer.model_id == cfg.model.pretrained_model_name_or_path)]
     df_answer = df_answer.sort_values(['question_id'])
@@ -197,20 +208,19 @@ def mtbench_evaluate():
     df_judge = df_judge.sort_values(['question_id', 'turn'])
 
     ## merge tables
-    #df_judge["question"] = np.nan
+    print("Debug: Merge tables")
     df_judge["question"] = pd.Series(np.nan, dtype='object')
-    
     df_judge.loc[df_judge.turn == 1, 'question'] = df_question_repeat.turns.apply(lambda x: x[0]).values
     df_judge.loc[df_judge.turn == 2, 'question'] = df_question_repeat.turns.apply(lambda x: x[1]).values
 
-    #df_judge['answer'] = np.nan
     df_judge['answer'] = pd.Series(np.nan, dtype='object')
-    df_judge.loc[df_judge.turn == 1, 'answer'] = df_answer_repeat.choices.apply(lambda x: x[0][ 'turns'][0]).values
-    df_judge.loc[df_judge.turn == 2, 'answer'] = df_answer_repeat.choices.apply(lambda x: x[0][ 'turns'][1]).values
+    df_judge.loc[df_judge.turn == 1, 'answer'] = df_answer_repeat.choices.apply(lambda x: x[0]['turns'][0]).values
+    df_judge.loc[df_judge.turn == 2, 'answer'] = df_answer_repeat.choices.apply(lambda x: x[0]['turns'][1]).values
     df_judge = df_judge.merge(df_answer[['question_id', 'answer_id']], on='question_id', how='left')
     df_judge = df_judge.merge(df_question[['question_id', 'category']], on='question_id', how='left')
 
     ## clean dataframe up
+    print("Debug: Clean dataframe up")
     use_col = [
         'question_id', 'category', 'answer_id', 'model', 'question', 
         'answer', 'judge', 'user_prompt', 'judgment', 
@@ -221,11 +231,13 @@ def mtbench_evaluate():
     table_log = wandb.Table(dataframe=df_judge)
 
     # table for radar chart
+    print("Debug: Create table for radar chart")
     _df_judge = df_judge.query('score != -1').groupby(['question_id', 'turn', 'category'], as_index=False).score.mean()
     df_summary = _df_judge.groupby(['category'], as_index=False).score.mean()
     table_radar = wandb.Table(dataframe=df_summary)
 
     ## table for LB mtbench
+    print("Debug: Create table for LB mtbench")
     columns = ['basemodel_name'] + df_summary.category.values.tolist()
     data = [[cfg.model.pretrained_model_name_or_path] + df_summary.score.values.tolist()]
     mtbench_df = pd.DataFrame(data, columns=columns)
@@ -239,7 +251,5 @@ def mtbench_evaluate():
         "mtbench_radar_table":table_radar,
     })
 
-    
-    #run.finish()
+    print("Debug: End mtbench_evaluate")
     return
-


### PR DESCRIPTION
MTbenchで並列処理を実装。
yamlで決定できるparallel（worker数）に依存するがデフォルトの40に設定すると生成とジャッジをOpenAI APIを使用した場合、
26m 13s → 1m 18s
に短縮

リファクタはまだ未実施