### PR TITLE
Aggregate Results and Update Toxicity Dataset and Evaluation

### DIFF
--- a/configs/base_config.yaml
+++ b/configs/base_config.yaml
@@ -44,11 +44,11 @@ sample_dataset:
   language: 'ja'
 
 toxicity:
-  artifact_path: 'wandb-japan/toxicity-dataset-private/toxicity_dataset_subset:v1'
+  artifact_path: 'wandb-japan/toxicity-dataset-private/toxicity_dataset_full:v3'
   judge_prompts_path: 'wandb-japan/toxicity-dataset-private/toxicity_judge_prompts:v1'
   max_workers: 5
   judge_model: 'gpt-4o-2024-05-13'
-  visualize_ids: '[0, 1]'
+  visualize_ids: '[0, 1, 2, 3, 4, 5, 6 ,7 ,8 ,9, 10, 11]'
 
 mtbench:
   temperature_override:

--- a/requirements.txt
+++ b/requirements.txt
@@ -208,4 +208,4 @@ wheel
 langchain_community
 questionary
 backoff
--sacrebleu[ja]
+sacrebleu[ja]

--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -5,21 +5,43 @@ import pandas as pd
 from utils import read_wandb_table
 from config_singleton import WandbConfigSingleton
 
+def calculate_combined_means(cols_jaster, cols_mtbench):
+    means = []
+    # jaster0とjasterfewshotsの共通の列の平均を計算
+    for col in cols_jaster:
+        if col in jaster_0shot.columns and col in jaster_fewshots.columns:
+            mean_value = (jaster_0shot[col].mean() + jaster_fewshots[col].mean()) / 2
+            means.append(mean_value)
+        else:
+            means.append(np.nan)  # 共通の列がない場合はNaNを追加
+    combined_means = []
+    # mtbenchの列と先ほどの平均値のリストの平均を計算
+    for i, col in enumerate(cols_mtbench):
+        if col in mtbench.columns:
+            mtbench_mean = mtbench[col].mean()
+            combined_mean = (means[i] + mtbench_mean) / 2 if not np.isnan(means[i]) else mtbench_mean
+            combined_means.append(combined_mean)
+        else:
+            combined_means.append(np.nan)  # 列がない場合はNaNを追加
+    return np.mean(combined_means)
+
 def aggregate():
-    instance = WandbConfigSingleton.get_instance()
     instance = WandbConfigSingleton.get_instance()
     run = instance.run
     cfg = instance.config
 
     few_shots=cfg.num_few_shots
 
-    jaster_0shot=read_wandb_table(f"jaster_{few_shots}shot_leaderboard_table")
+    jaster_0shot=read_wandb_table(f"jaster_0shot_leaderboard_table")
     jaster_fewshots= read_wandb_table(f"jaster_{few_shots}shot_leaderboard_table")
     jmmlu_robost_fewshots=read_wandb_table(f"jmmlu_robost_{few_shots}shot_leaderboard_table")
+    jaster_control_0shot=read_wandb_table(f"jaster_control_0shot_leaderboard_table")
     jaster_control_fewshots=read_wandb_table(f"jaster_control_{few_shots}shot_leaderboard_table")
-    lctg_overall_leaderboard_table=read_wandb_table(f"lctg_overall_leaderboard_table")
-    jbbq_0shot_leaderboard_table=read_wandb_table(f"jbbq_0shot_leaderboard_table")
-    jbbq_4shot_leaderboard_table=read_wandb_table(f"jbbq_{few_shots}shot_leaderboard_table")
+    lctg_overall=read_wandb_table(f"lctg_overall_leaderboard_table")
+    jbbq_0shot=read_wandb_table(f"jbbq_0shot_leaderboard_table")
+    jbbq_4shot=read_wandb_table(f"jbbq_{few_shots}shot_leaderboard_table")
+    toxicity=read_wandb_table(f"toxicity_leaderboard_table")
+    mtbench=read_wandb_table(f"mtbench_leaderboard_table")
     
     print("-------- aggregating results ----------")
 
@@ -30,7 +52,7 @@ def aggregate():
                                         "model_size",
                                         "GLP_expression",
                                         "GLP_translation",
-                                        "GLP_summarization",
+                                        #"GLP_summarization",
                                         "GLP_information_extraction",
                                         "GLP_reasoning",
                                         "GLP_mathematical_reasoning",
@@ -43,35 +65,38 @@ def aggregate():
                                         "ALT_ethics_moral",
                                         "ALT_toxicity",
                                         "ALT_bias",
-                                        "ALT_truthfulness",
+                                        #"ALT_truthfulness",
                                         "ALT_robustness",
                                         "GLP_AVG",
-                                        "LT_AVG",
+                                        "ALT_AVG",
                                         "TOTAL_AVG"
                                     ])
     
+    glp_columns = [col for col in leaderboard_table.columns if 'GLP' in col and 'AVG' not in col]
+    alt_columns = [col for col in leaderboard_table.columns if 'ALT' in col and 'AVG' not in col]
+
     leaderboard_table["model_release_date"] = cfg.model.release_date
     leaderboard_table["model_size"] = cfg.model.size
-    leaderboard_table["GLP_expression"] = 
-    leaderboard_table["GLP_translation"] = 
-    leaderboard_table["GLP_summarization"] =
-    leaderboard_table["GLP_information_extraction"] =
-    leaderboard_table["GLP_reasoning"] =
-    leaderboard_table["GLP_mathematical_reasoning"] =
-    leaderboard_table["GLP_entity_extraction"] =
-    leaderboard_table["GLP_knowledge_QA"] =
-    leaderboard_table["GLP_English_MMLU"] =
-    leaderboard_table["GLP_semantic_analysis"] =
-    leaderboard_table["GLP_syntactic_analysis"] =
-    leaderboard_table["ALT_controllability"] =
-    leaderboard_table["ALT_ethics_moral"] =
-    leaderboard_table["ALT_toxicity"] =
-    leaderboard_table["ALT_bias"] =
-    leaderboard_table["ALT_truthfulness"] =
-    leaderboard_table["ALT_robustness"] =
-    leaderboard_table["GLP_AVG"] =
-    leaderboard_table["LT_AVG"] =
-    leaderboard_table["TOTAL_AVG"] =
+    leaderboard_table["GLP_expression"] = calculate_combined_means([],["roleplay","writing","humanities"])
+    leaderboard_table["GLP_translation"] = calculate_combined_means(["alt-e-to-j","alt-j-to-e","wikicorpus-e-to-j","wikicorpus-j-to-e"], [])
+    #leaderboard_table["GLP_summarization"] =
+    leaderboard_table["GLP_information_extraction"] = calculate_combined_means(["jsquad"], [])
+    leaderboard_table["GLP_reasoning"] = calculate_combined_means([], ["reasoning"])
+    leaderboard_table["GLP_mathematical_reasoning"] = calculate_combined_means(["mawps", "jmmlu_stem"], ["math"])
+    leaderboard_table["GLP_entity_extraction"] = calculate_combined_means(["wiki_ner", "wiki_coreference", "chabsa"], ["extraction"])
+    leaderboard_table["GLP_knowledge_QA"] = calculate_combined_means(["jcommonsenseqa","jemhopqa","jmmlu_humanities","jmmlu_social_sciences","jmmlu_other","niilc","aio"], [])
+    leaderboard_table["GLP_English_MMLU"] = calculate_combined_means(["mmlu_en"], [])
+    leaderboard_table["GLP_semantic_analysis"] = calculate_combined_means(["jnli","janli","jsem","jsick", "jamp"], [])
+    leaderboard_table["GLP_syntactic_analysis"] = calculate_combined_means(["jcola-in-domain","jcola-out-of-domain","jblimp","wiki_reading","wiki_pas","wiki_dependency"], [])
+    leaderboard_table["ALT_controllability"] = np.mean(np.mean([jaster_control_0shot["AVG"], jaster_control_fewshots["AVG"]]), np.mean(lctg_overall_leaderboard_table[["Format-ctg","C-count-ctg","Keyword-ctg","P-word-ctg"]]))
+    leaderboard_table["ALT_ethics_moral"] = calculate_combined_means(["commonsensemoralja"],[])
+    leaderboard_table["ALT_toxicity"] = toxicity_leaderboard_table[["公平性", "社会規範", "禁止行為", "違反カテゴリ"]].values.mean() if 'toxicity_leaderboard_table' in locals() else np.nan
+    leaderboard_table["ALT_bias"] = 1-np.mean(jbbq_0shot["avg_abs_bias_score"], jbbq_fewshots["avg_abs_bias_score"])
+    #leaderboard_table["ALT_truthfulness"] = 
+    leaderboard_table["ALT_robustness"] = jmmlu_robost_fewshots["jmmlu_robustness"]
+    leaderboard_table["GLP_AVG"] = leaderboard_table.filter(like='GLP').mean()
+    leaderboard_table["ALT_AVG"] = leaderboard_table.filter(like='ALT').mean()
+    leaderboard_table["TOTAL_AVG"] = np.mean(leaderboard_table["GLP_AVG"], leaderboard_table["ALT_AVG"])
 
     
     run.log({"leaderboard_table": instance.table})

--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -72,8 +72,6 @@ def aggregate():
                                         "TOTAL_AVG"
                                     ])
     
-    glp_columns = [col for col in leaderboard_table.columns if 'GLP' in col and 'AVG' not in col]
-    alt_columns = [col for col in leaderboard_table.columns if 'ALT' in col and 'AVG' not in col]
 
     leaderboard_table["model_release_date"] = cfg.model.release_date
     leaderboard_table["model_size"] = cfg.model.size
@@ -88,7 +86,7 @@ def aggregate():
     leaderboard_table["GLP_English_MMLU"] = calculate_combined_means(["mmlu_en"], [])
     leaderboard_table["GLP_semantic_analysis"] = calculate_combined_means(["jnli","janli","jsem","jsick", "jamp"], [])
     leaderboard_table["GLP_syntactic_analysis"] = calculate_combined_means(["jcola-in-domain","jcola-out-of-domain","jblimp","wiki_reading","wiki_pas","wiki_dependency"], [])
-    leaderboard_table["ALT_controllability"] = np.mean(np.mean([jaster_control_0shot["AVG"], jaster_control_fewshots["AVG"]]), np.mean(lctg_overall_leaderboard_table[["Format-ctg","C-count-ctg","Keyword-ctg","P-word-ctg"]]))
+    leaderboard_table["ALT_controllability"] = np.mean(np.mean([jaster_control_0shot["AVG"], jaster_control_fewshots["AVG"]]), lctg_overall_leaderboard_table[["Total-AVG-ctg"]])
     leaderboard_table["ALT_ethics_moral"] = calculate_combined_means(["commonsensemoralja"],[])
     leaderboard_table["ALT_toxicity"] = toxicity_leaderboard_table[["公平性", "社会規範", "禁止行為", "違反カテゴリ"]].values.mean() if 'toxicity_leaderboard_table' in locals() else np.nan
     leaderboard_table["ALT_bias"] = 1-np.mean(jbbq_0shot["avg_abs_bias_score"], jbbq_fewshots["avg_abs_bias_score"])

--- a/scripts/evaluator/jaster.py
+++ b/scripts/evaluator/jaster.py
@@ -241,7 +241,8 @@ def evaluate_n_shot(few_shots: bool):
         columns="task",
         aggfunc="mean",
     ).reset_index()
-
+    leaderboard_table_control['AVG'] = leaderboard_table.iloc[:, 2:].mean(axis=1)
+    leaderboard_table_control['AVG'] = leaderboard_table_control.iloc[:, 2:].mean(axis=1)
     leaderboard_table['jmmlu'] = leaderboard_table[['jmmlu_stem', 'jmmlu_social_sciences', 'jmmlu_humanities', 'jmmlu_other']].mean(axis=1)
     leaderboard_table_control['jmmlu'] = leaderboard_table_control[['jmmlu_stem', 'jmmlu_social_sciences', 'jmmlu_humanities', 'jmmlu_other']].mean(axis=1)
 

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -8,6 +8,7 @@ import pandas as pd
 from pathlib import Path
 import torch
 import wandb
+from tenacity import retry, stop_after_attempt, wait_fixed
 
 from config_singleton import WandbConfigSingleton
 
@@ -23,7 +24,7 @@ def cleanup_gpu():
     gc.collect()
     torch.cuda.empty_cache()
 
-
+@retry(stop=stop_after_attempt(10), wait=wait_fixed(10))
 def read_wandb_table(
     table_name: str,
     run: object = None,


### PR DESCRIPTION
## Aggregate Results and Update Toxicity Dataset

### This PR includes the following changes:

1. Updated the toxicity dataset artifact to use the full dataset instead of a subset. The artifact path has been updated in `configs/base_config.yaml`.

2. Improved the `aggregate.py` script:
   - Added a new function `calculate_combined_means()` to calculate the combined means of columns from jaster, mtbench, and other datasets.
   - Updated the leaderboard table calculations to use the new `calculate_combined_means()` function for various GLP and ALT metrics.
   - Fixed some typos and formatting issues.

3. Modified the `jaster.py` script to calculate the average scores for JMMLU categories in both the regular and control leaderboard tables.

4. Enhanced the `toxicity_eval.py` script:
   - Increased the retry attempts and wait time for the `judge_extract_scores()` function to handle potential network issues.
   - Added a `max_workers` parameter to the `get_scores()` function to enable parallel processing of questions.
   - Implemented parallel processing using `ThreadPoolExecutor` to speed up the evaluation process.
   - Updated the code to handle unknown categories gracefully and return the question without scores.
   - Modified the sample selection for the toxicity output table.

5. Added @retry to read_wandb_table  in `utils.py`.

These changes improve the aggregation of results across different datasets, update the toxicity dataset to use the full version, and optimize the toxicity evaluation process for better performance and error handling.

Please review the changes and provide any feedback or suggestions.