### PR TITLE
fix around max-model-len and model parallel

### DIFF
--- a/configs/config-Meta-Llama-3-70B-Instruct.yaml
+++ b/configs/config-Meta-Llama-3-70B-Instruct.yaml
@@ -4,6 +4,7 @@ wandb:
 # if you don't use api, please set "api" as "false"
 # if you use api, please select from "openai", "anthoropic", "google", "cohere", "vllm"
 api: vllm
+num_gpus: 2
 batch_size: 256 # vllmは256, apiは32を推奨
 
 model:

--- a/configs/config-Mixtral-8x7B-Instruct-v0-1.yaml
+++ b/configs/config-Mixtral-8x7B-Instruct-v0-1.yaml
@@ -4,6 +4,7 @@ wandb:
 # if you don't use api, please set "api" as "false"
 # if you use api, please select from "openai", "anthoropic", "google", "cohere", "vllm"
 api: vllm
+num_gpus: 2
 batch_size: 256 # vllmは256, apiは32を推奨
 
 model:

--- a/configs/config-Qwen1-5-72B-Chat.yaml
+++ b/configs/config-Qwen1-5-72B-Chat.yaml
@@ -4,6 +4,7 @@ wandb:
 # if you don't use api, please set "api" as "false"
 # if you use api, please select from "openai", "anthoropic", "google", "cohere", "vllm"
 api: vllm
+num_gpus: 2
 batch_size: 256 # vllmは256, apiは32を推奨
 
 model:

--- a/configs/config-Yi-34B-Chat.yaml
+++ b/configs/config-Yi-34B-Chat.yaml
@@ -4,6 +4,7 @@ wandb:
 # if you don't use api, please set "api" as "false"
 # if you use api, please select from "openai", "anthoropic", "google", "cohere", "vllm"
 api: vllm
+num_gpus: 2
 batch_size: 256 # vllmは256, apiは32を推奨
 
 model:

--- a/configs/config-llm-jp-13b-instruct-full-dolly-ichikara_004_001_single-oasst-oasst2-v2-0.yaml
+++ b/configs/config-llm-jp-13b-instruct-full-dolly-ichikara_004_001_single-oasst-oasst2-v2-0.yaml
@@ -4,6 +4,7 @@ wandb:
 # if you don't use api, please set "api" as "false"
 # if you use api, please select from "openai", "anthoropic", "google", "cohere", "vllm"
 api: vllm
+num_gpus: 2
 batch_size: 256 # vllmは256, apiは32を推奨
 
 model:


### PR DESCRIPTION
- context lengthが短いモデル向けにmax-model-lenのデフォルト値を2048に設定しました。
- 複数のGPUを有効化できるようにmodel parallelの引数を追加しました。