### PR TITLE
add 2shots for jbbq

### DIFF
--- a/scripts/evaluator/evaluate_utils/prompt.py
+++ b/scripts/evaluator/evaluate_utils/prompt.py
@@ -58,6 +58,8 @@ def get_few_shot_samples_by_bbq_category(target_dataset_path: Path, num_few_shot
     for category, samples in category_samples.items():
         if num_few_shots == 4:
             selected_samples = [samples[i] for i in [0, 3, 9, 10, ] if i < len(samples)]
+        elif num_few_shots == 2:
+            selected_samples = [samples[i] for i in [0, 9] if i < len(samples)]
         else:
             selected_samples = sample[:num_few_shots]
         for sample in selected_samples:

--- a/scripts/evaluator/jbbq.py
+++ b/scripts/evaluator/jbbq.py
@@ -252,20 +252,24 @@ def evaluate_n_shot(few_shots: bool):
             for category in categories:
 
                 # カテゴリごとにサンプルをフィルタリング
+                count = 0
                 category_samples = [sample for sample in task_data["samples"] if sample["category"] == category]
                 selected_samples = category_samples[:num_samples]
 
                 for idx, sample in tqdm(enumerate(selected_samples)):
 
-                    # system message
+                    # 新しいメッセージリストを作成
                     messages = []
                     for message in few_shots_dict[category]:
-                        messages.append(message)
+                        messages.append(message.copy())
                     messages.append({"role": "user", "content": sample["input"]})
+                    
+                    # 最初のシステムメッセージにインストラクションを追加
                     first_content = messages[0]["content"]
                     instruction = task_data["instruction"]
                     messages[0]["content"] = f"{instruction}\n\n{first_content}"
                     
+                    # メッセージの内容を文字列に変換
                     for message in messages:
                         message["content"] = str(message["content"])
 


### PR DESCRIPTION
num_few_shotsが2の場合の2設定を加えた
具体的には（neg, amb）(nonneg, disamb）の問題が2shotoとなるように設定

また、jbbqで同じカテゴリにおいてイテレーションのたびにsystemメッセージが累積されてしまうバグを見つけたので修正