### PR TITLE
Fix around processing model output

### DIFF
--- a/scripts/evaluator/jaster.py
+++ b/scripts/evaluator/jaster.py
@@ -204,6 +204,7 @@ def evaluate_n_shot(few_shots: bool):
             raw_output,
             lambda x: text_formatter(x, task),
             lambda x: x.split("\n\n")[0],
+            lambda x: x.strip("'").strip('"'),
             normalize,
         )
         metrics_func = evaluation_result["metrics_func"]


### PR DESCRIPTION
GPT-4がmmlu_enの回答にquoteを含めてしまうので、前後のクォートを除外するように変更。
この変更により他のデータセットでもscoreが上がる可能性あり