### PR TITLE
Add a parameter for the number of parallel judgment

### DIFF
--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -60,6 +60,7 @@ mtbench:
   max_gpu_memory: null
   dtype: bfloat16 # None or float32 or float16 or bfloat16
   use_azure: false # if you use azure openai service for evaluation, set true
+  parallel: 1 # set number of parallel judgment
   # for conv template # added
   custom_conv_template: false
   # the following variables will be used when custom_conv_template is set as true

--- a/scripts/run_eval.py
+++ b/scripts/run_eval.py
@@ -31,12 +31,15 @@ if os.path.exists("configs/config.yaml"):
             "mode": "single",
             "num_choices": 1,
             "baseline_model": None,
-            "parallel": 80,
             "first_n": None,
         }
     }
     for key, value in default_settings.items():
         cfg_dict[key].update(value)
+
+    if 'parallel' not in cfg_dict.get('mtbench', {}):
+        cfg_dict['mtbench']['parallel'] = 1
+
     assert isinstance(cfg_dict, dict)
 else:
     raise FileNotFoundError("config.yaml file does not exist.")


### PR DESCRIPTION
- Set the number of parallel processes in the config's 'parallel' parameter to parallelize the judgment process.