### PR TITLE
Fix mtbench reference

### DIFF
--- a/configs/base_config.yaml
+++ b/configs/base_config.yaml
@@ -1,6 +1,6 @@
 wandb:
-  entity: "llm-leaderboard"
-  project: "nejumi-leaderboard4-dev"
+  entity: 'llm-leaderboard'
+  project: 'nejumi-leaderboard4-dev'
   #run: please set up run name in a model-base config
 
 github_version: v3.0.0 #for recording
@@ -11,12 +11,12 @@ inference_interval: 0 # seconds
 run:
   jaster: true
   jmmlu_robustness: true # if this is set as true, jaster should set as true
-  mtbench: true
-  jbbq: true
-  toxicity: true
-  jtruthfulqa: true
-  swebench: true
-  hallulens: true
+  mtbench: false
+  jbbq: false
+  toxicity: false
+  jtruthfulqa: false
+  swebench: false
+  hallulens: false
   aggregate: false
 
 model:
@@ -25,7 +25,7 @@ model:
   chat_template: null
   dtype: 'float16'
   trust_remote_code: true
-  device_map: "auto"
+  device_map: 'auto'
   load_in_8bit: false
   load_in_4bit: false
 
@@ -37,33 +37,32 @@ generator:
 num_few_shots: 2
 
 jaster:
-  message_intro: "以下に、あるタスクを説明する指示があり、それに付随する入力が更なる文脈を提供しています。リクエストを適切に完了するための回答を記述してください。"
-  artifacts_path: "llm-leaderboard/nejumi-leaderboard4/jaster:v0"
-  dataset_dir: "jaster"
-
+  message_intro: '以下に、あるタスクを説明する指示があり、それに付随する入力が更なる文脈を提供しています。リクエストを適切に完了するための回答を記述してください。'
+  artifacts_path: 'llm-leaderboard/nejumi-leaderboard4/jaster:production'
+  dataset_dir: 'jaster'
 
 jbbq:
-  artifacts_path: 'llm-leaderboard/nejumi-leaderboard4-private/jbbq:v0'
+  artifacts_path: 'llm-leaderboard/nejumi-leaderboard4-private/jbbq:production'
   dataset_dir: 'jbbq'
   language: 'ja'
 
 toxicity:
-  artifact_path: 'llm-leaderboard/nejumi-leaderboard4-private/toxicity_dataset_full:v0'
-  judge_prompts_path: 'llm-leaderboard/nejumi-leaderboard4-private/toxicity_judge_prompts:v0'
+  artifact_path: 'llm-leaderboard/nejumi-leaderboard4-private/toxicity_dataset_full:production'
+  judge_prompts_path: 'llm-leaderboard/nejumi-leaderboard4-private/toxicity_judge_prompts:production'
   max_workers: 5
   judge_model: 'gpt-4o-2024-05-13'
 
 jtruthfulqa:
-  artifact_path: 'llm-leaderboard/nejumi-leaderboard4/jtruthfulqa_dataset:v0'  # JTruthfulQAデータセットのアーティファクトパス
+  artifact_path: 'llm-leaderboard/nejumi-leaderboard4/jtruthfulqa_dataset:production'  # JTruthfulQAデータセットのアーティファクトパス
   roberta_model_name: 'nlp-waseda/roberta_jtruthfulqa'  # 評価に使用するRoBERTaモデル名
 
 swebench:
-  artifacts_path: 'llm-leaderboard/nejumi-leaderboard4/swebench_verified_official:v0'  # SWE-Bench Verifiedデータセットのアーティファクトパス
-  dataset_dir: "swebench_verified_official"
+  artifacts_path: 'llm-leaderboard/nejumi-leaderboard4/swebench_verified_official:production'  # SWE-Bench Verifiedデータセットのアーティファクトパス
+  dataset_dir: 'swebench_verified_official'
   max_samples: 100  # 全500件は時間がかかるため制限（フルセットの場合は500を指定）
   max_tokens: 2048  # SWE-Benchのパッチ生成に必要なトークン数
   max_workers: 4  # 並列実行ワーカー数
-  evaluation_method: "official"  # "official" or "docker" - 公式パッケージまたは独自Docker実装
+  evaluation_method: 'official'  # 'official' or 'docker' - 公式パッケージまたは独自Docker実装
 
 mtbench:
   temperature_override:
@@ -74,14 +73,14 @@ mtbench:
     coding: 0.0
     reasoning: 0.0
     stem: 0.1
-    humanities": 0.1
-  question_artifacts_path: 'llm-leaderboard/nejumi-leaderboard4/mtbench_ja_question:v0' # if testmode is true, small dataset will be used
-  question_artifacts_path_test: 'llm-leaderboard/nejumi-leaderboard4/mtbench_ja_question_small_for_test:v0'
-  referenceanswer_artifacts_path: 'llm-leaderboard/nejumi-leaderboard4/mtbench_ja_referenceanswer:v0' # if testmode is true, small dataset will be used
-  referenceanswer_artifacts_path_test: 'llm-leaderboard/nejumi-leaderboard4/mtbench_ja_referenceanswer_small_for_test:v0'
-  judge_prompt_artifacts_path: 'llm-leaderboard/nejumi-leaderboard4/mtbench_ja_prompt:v0' 
+    humanities': 0.1
+  question_artifacts_path: 'llm-leaderboard/nejumi-leaderboard4/mtbench_ja_question:production' # if testmode is true, small dataset will be used
+  question_artifacts_path_test: 'llm-leaderboard/nejumi-leaderboard4/mtbench_ja_question_small_for_test:production'
+  referenceanswer_artifacts_path: 'llm-leaderboard/nejumi-leaderboard4/mtbench_ja_referenceanswer:production' # if testmode is true, small dataset will be used
+  referenceanswer_artifacts_path_test: 'llm-leaderboard/nejumi-leaderboard4/mtbench_ja_referenceanswer_small_for_test:production'
+  judge_prompt_artifacts_path: 'llm-leaderboard/nejumi-leaderboard4/mtbench_ja_prompt:production' 
   bench_name: 'japanese_mt_bench'
-  model_id: null # cannot use '<', '>', ':', '"', '/', '\\', '|', '?', '*', '.'
+  model_id: null # cannot use '<', '>', ':', ''', '/', '\\', '|', '?', '*', '.'
   question_begin: null 
   question_end: null 
   max_new_token: 1024
@@ -97,10 +96,11 @@ mtbench:
   parallel: 80
   first_n: null
 
+hallulens:
+  artifacts_path: 'llm-leaderboard/nejumi-leaderboard4/hallulens:production'
+  judge_model: 'gpt-4o'
+
 sample_dataset:
-  artifacts_path: "your artifact path here"
+  artifacts_path: 'your artifact path here'
   # add necessary configration here
 
-hallulens:
-  artifacts_path: "llm-leaderboard/nejumi-leaderboard4/hallulens:v0"
-  judge_model: "gpt-4o"

--- a/scripts/data_uploader/upload_mtbench_referenceanswer.py
+++ b/scripts/data_uploader/upload_mtbench_referenceanswer.py
@@ -17,14 +17,6 @@ parser.add_argument(
 )
 
 parser.add_argument(
-    "-v",
-    "--dataset_version",
-    type=str,
-    required=True
-)
-
-
-parser.add_argument(
     "-f",
     "--file_path",
     type=str,
@@ -32,11 +24,18 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
+# 2025-06-30
+# Use swallow evaluation dataset : 
+metadata = {
+    "original_dataset": "https://github.com/swallow-llm/swallow-evaluation/tree/main/fastchat/fastchat/llm_judge/data/japanese_mt_bench",
+}
+description = "This is based on the refrence answer dataset developed by the evaluation team of Swallow project. URL: https://github.com/swallow-llm/swallow-evaluation/tree/main"
+
 with wandb.init(entity=args.entity, project=args.project, job_type="upload_data") as run:
     dataset_artifact = wandb.Artifact(name="mtbench_ja_referenceanswer", 
                                     type="dataset", 
-                                    metadata={"version":args.dataset_version},
-                                    description="This dataset is based on version {}".format(args.dataset_version))
+                                    metadata=metadata,
+                                    description=description)
     
     # track lineage
     run.use_artifact('wandb-japan/llm-leaderboard/mtbench_ja_prompt:v0', type='dataset')


### PR DESCRIPTION
This pull request updates the `configs/base_config.yaml` file and modifies the `upload_mtbench_referenceanswer.py` script to improve configuration management and metadata handling. The most significant changes include switching artifact paths to production versions, altering boolean flags for specific benchmarks, and adding detailed metadata for the dataset upload process.

### Configuration Updates in `configs/base_config.yaml`:

* Changed artifact paths for various benchmarks (`jaster`, `jbbq`, `toxicity`, `jtruthfulqa`, `swebench`, `mtbench`, and `hallulens`) to their production versions for improved consistency and deployment readiness. [[1]](diffhunk://#diff-6c274cd745c998c5c4673e7b0aa803182c9eef7c6b2c618ad93dffd0c3cc2960L40-R65) [[2]](diffhunk://#diff-6c274cd745c998c5c4673e7b0aa803182c9eef7c6b2c618ad93dffd0c3cc2960L77-R83) [[3]](diffhunk://#diff-6c274cd745c998c5c4673e7b0aa803182c9eef7c6b2c618ad93dffd0c3cc2960R99-L106)
* Updated boolean flags for benchmark tests (`mtbench`, `jbbq`, `toxicity`, `jtruthfulqa`, `swebench`, and `hallulens`) to `false` to disable these evaluations by default.

### Metadata and Script Enhancements in `upload_mtbench_referenceanswer.py`:

* Removed the `dataset_version` argument from the script to simplify the upload process.
* Added detailed metadata and description for the dataset artifact, referencing the Swallow evaluation project's original dataset. This improves traceability and documentation.

### Miscellaneous Changes:

* Standardized quotation marks across the configuration file for consistency (`"auto"` → `'auto'`, etc.). [[1]](diffhunk://#diff-6c274cd745c998c5c4673e7b0aa803182c9eef7c6b2c618ad93dffd0c3cc2960L2-R3) [[2]](diffhunk://#diff-6c274cd745c998c5c4673e7b0aa803182c9eef7c6b2c618ad93dffd0c3cc2960L28-R28) [[3]](diffhunk://#diff-6c274cd745c998c5c4673e7b0aa803182c9eef7c6b2c618ad93dffd0c3cc2960L77-R83)