### PR TITLE
Parallelize SWE-bench evaluation, support local Arrow dataset, update…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,7 @@ fastchat/llm_judge/data/japanese_mt_bench
 
 # vllm
 *.pid
+
+#BFCL outputs
+BFCL*.json
+scripts/evaluator/evaluate_utils/bfcl_pkg/score/

--- a/configs/base_config.yaml
+++ b/configs/base_config.yaml
@@ -62,9 +62,9 @@ jtruthfulqa:
 swebench:
   artifacts_path: 'llm-leaderboard/nejumi-leaderboard4/swebench_verified_official:production'  # SWE-Bench Verifiedデータセットのアーティファクトパス
   dataset_dir: 'swebench_verified_official'
-  max_samples: 100  # 全500件は時間がかかるため制限（フルセットの場合は500を指定）
+  max_samples: 50  # 全500件は時間がかかるため制限（フルセットの場合は500を指定）
   max_tokens: 2048  # SWE-Benchのパッチ生成に必要なトークン数
-  max_workers: 4  # 並列実行ワーカー数
+  max_workers: 8  # 並列実行ワーカー数
   evaluation_method: 'official'  # 'official' or 'docker' - 公式パッケージまたは独自Docker実装
 
 mtbench:
@@ -114,11 +114,11 @@ bfcl:
   artifacts_path: 'llm-leaderboard/nejumi-leaderboard4/bfcl:production'
 
 hallulens:
-  artifacts_path: 'llm-leaderboard/nejumi-leaderboard4/hallulens:production'
+  artifacts_path: 'llm-leaderboard/nejumi-leaderboard4/hallulens:v1'
   judge_model: 'gpt-4o'
   
 hle:
-  artifact_path: 'llm-leaderboard/hle-test/hle-ja:production'
+  artifact_path: 'llm-leaderboard/nejumi-leaderboard4/hle-ja:production'
   dataset_name: 'hle-ja.jsonl'
   max_completion_tokens: 8192
   max_workers: 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "omegaconf>=2.3.0",
     "openai>=1.86.0",  # より新しい方に統一
     "overrides",
+    "matplotlib>=3.10.3",
     "pandas>=2.3.0",
     "pathlib",
     "pydantic>=2.8.2",


### PR DESCRIPTION
# Parallelize SWE-bench evaluation and support local Arrow dataset

## Summary
This PR improves the SWE-bench evaluation system by adding parallelization, local dataset support, and better error handling.

## Changes

### Core Improvements
- **Parallelized SWE-bench evaluation**: Optimized patch generation and evaluation processes for better performance
- **Local Arrow dataset support**: Added capability to evaluate using local Arrow-format datasets instead of requiring internet access
- **Enhanced error handling**: Improved logging and error recovery mechanisms

### Configuration Updates
- Adjusted SWE-bench parameters (`max_samples: 100 → 50`, `max_workers: 4 → 8`)
- Updated artifact paths for BFCL, HLE, and Hallulens evaluations
- Added matplotlib dependency for potential visualization features

### Development Experience
- Added BFCL output files and score directories to `.gitignore` to prevent accidental commits of generated data

## Technical Details
- Modified `swebench_official.py` to support both local file-based and internet-based dataset evaluation
- Implemented fallback mechanism when local evaluation fails
- Enhanced logging with detailed traceback information for debugging

## Testing
- Test Run: [https://wandb.ai/llm-leaderboard/nejumi-leaderboard4-dev/runs/az9aed6j](https://wandb.ai/llm-leaderboard/nejumi-leaderboard4-dev/runs/az9aed6j)