### PR TITLE
Reasoningモデル対応

### DIFF
--- a/Dockerfile.vllm
+++ b/Dockerfile.vllm
@@ -1,0 +1,15 @@
+ARG VLLM_VERSION=0.9.1
+FROM vllm/vllm-openai:${VLLM_VERSION}
+
+ENV YQ_VERSION=v4.45.4
+ENV YQ_BINARY=yq_linux_amd64
+
+RUN curl -L https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/${YQ_BINARY} -o /usr/bin/yq && \
+    chmod +x /usr/bin/yq
+
+COPY docker-entrypoint-vllm.sh /usr/bin/docker-entrypoint-vllm.sh
+RUN chmod +x /usr/bin/docker-entrypoint-vllm.sh
+
+WORKDIR /workspace
+
+ENTRYPOINT ["/usr/bin/docker-entrypoint-vllm.sh"]

--- a/configs/base_config.yaml
+++ b/configs/base_config.yaml
@@ -24,6 +24,7 @@ run:
 
 model:
   artifact_path: null
+  ### deprecated: for in-process vllm launch ###
   max_model_len: 3000
   chat_template: null
   dtype: 'float16'
@@ -31,8 +32,19 @@ model:
   device_map: 'auto'
   load_in_8bit: false
   load_in_4bit: false
+  ### deprecated ###
 
-generator:
+vllm: # vLLM server-side launch configuration
+  extra_args: []
+  # example
+  # extra_args:
+  #   - --dtype=bfloat16
+  #   - --max_model_len=3000
+  #   - '--override_generation_config={"temperature":0.6,"top_p":0.95}' # do not include space
+  #   - --trust_remote_code
+  #   - --reasoning-parser=deepseek_r1
+
+generator: # LLM client default configuration: to be overridden by each benchmark
   top_p: 1.0
   temperature: 0.1
   max_tokens: 128

--- a/configs/base_config.yaml
+++ b/configs/base_config.yaml
@@ -65,6 +65,7 @@ jaster:
       write_timeout: 60.0                   # Write timeout in seconds
       enable_network: true                  # Enable network access in sandbox
       worker_timeout: 15                    # Worker process timeout in seconds
+  override_max_tokens: null # if null, use value defined in task dataset files
 
 jbbq:
   artifacts_path: 'llm-leaderboard/nejumi-leaderboard4-private/jbbq:production'
@@ -80,6 +81,8 @@ toxicity:
 jtruthfulqa:
   artifact_path: 'llm-leaderboard/nejumi-leaderboard4/jtruthfulqa_dataset:production'  # JTruthfulQAデータセットのアーティファクトパス
   roberta_model_name: 'nlp-waseda/roberta_jtruthfulqa'  # 評価に使用するRoBERTaモデル名
+  generator_config:
+    max_tokens: 256
 
 swebench:
   artifacts_path: 'llm-leaderboard/nejumi-leaderboard4/swebench_verified_official:production'  # SWE-Bench Verifiedデータセットのアーティファクトパス
@@ -138,6 +141,10 @@ bfcl:
 hallulens:
   artifacts_path: 'llm-leaderboard/nejumi-leaderboard4/hallulens:production'
   judge_model: 'gpt-4o'
+  generator_config:
+    max_tokens: 256
+    temperature: 0.0
+    top_p: 1.0
   
 hle:
   artifact_path: 'llm-leaderboard/nejumi-leaderboard4/hle-ja:production'

--- a/configs/base_config.yaml
+++ b/configs/base_config.yaml
@@ -71,6 +71,8 @@ jbbq:
   artifacts_path: 'llm-leaderboard/nejumi-leaderboard4-private/jbbq:production'
   dataset_dir: 'jbbq'
   language: 'ja'
+  generator_config:
+    max_tokens: 10
 
 toxicity:
   artifact_path: 'llm-leaderboard/nejumi-leaderboard4-private/toxicity_dataset_full:production'

--- a/configs/config-Qwen3-14B.yaml
+++ b/configs/config-Qwen3-14B.yaml
@@ -16,12 +16,17 @@ model:
   size: 1
   release_date: "4/28/2025"
 
+generator:
+  extra_body:
+    chat_template_kwargs:
+      enable_thinking: false
+
 testmode: true
 run:
   jaster: true
   jmmlu_robustness: true # if this is set as true, jaster should set as true
   mtbench: true
-  jbbq: false
+  jbbq: true
   toxicity: true
   jtruthfulqa: true
   hle: true

--- a/configs/config-Qwen3-14B.yaml
+++ b/configs/config-Qwen3-14B.yaml
@@ -1,0 +1,32 @@
+wandb:
+  run_name: "Qwen/Qwen3-14B" # use run_name defined above
+
+# if you don't use api, please set "api" as "false"
+# if you use api, please select from "openai", "anthoropic", "google", "cohere", "vllm"
+api: vllm-external
+base_url: 'http://vllm:8000/v1'
+num_gpus: 1
+batch_size: 256 # vllmは256, apiは32を推奨
+# inference_interval: 1 # seconds
+
+model:
+  use_wandb_artifacts: false
+  pretrained_model_name_or_path: "Qwen/Qwen3-14B" #if you use openai api, put the name of model
+  size_category: "10B≤ <30B"
+  size: 1
+  release_date: "4/28/2025"
+
+testmode: true
+run:
+  jaster: true
+  jmmlu_robustness: true # if this is set as true, jaster should set as true
+  mtbench: true
+  jbbq: false
+  toxicity: true
+  jtruthfulqa: true
+  hle: true
+  swebench: true
+  bfcl: false
+  hallulens: true
+  arc_agi_2: true
+  aggregate: false

--- a/configs/config-Qwen3-14B:reasoning.yaml
+++ b/configs/config-Qwen3-14B:reasoning.yaml
@@ -31,6 +31,10 @@ generator:
 jaster:
   override_max_tokens: 16384
 
+jbbq:
+  generator_config:
+    max_tokens: 16384
+
 jtruthfulqa:
   generator_config:
     max_tokens: 16384
@@ -67,7 +71,7 @@ run:
   jaster: true
   jmmlu_robustness: true # if this is set as true, jaster should set as true
   mtbench: true
-  jbbq: false
+  jbbq: true
   toxicity: true
   jtruthfulqa: true
   hle: true

--- a/configs/config-Qwen3-14B:reasoning.yaml
+++ b/configs/config-Qwen3-14B:reasoning.yaml
@@ -1,0 +1,78 @@
+wandb:
+  run_name: "Qwen/Qwen3-14B:reasoning" # use run_name defined above
+
+# if you don't use api, please set "api" as "false"
+# if you use api, please select from "openai", "anthoropic", "google", "cohere", "vllm"
+api: vllm-external
+base_url: 'http://vllm:8000/v1'
+num_gpus: 1
+batch_size: 256 # vllmは256, apiは32を推奨
+# inference_interval: 1 # seconds
+
+model:
+  use_wandb_artifacts: false
+  pretrained_model_name_or_path: "Qwen/Qwen3-14B" #if you use openai api, put the name of model
+  size_category: "10B≤ <30B"
+  size: 1
+  release_date: "4/28/2025"
+
+vllm: # vLLM server-side launch configuration
+  extra_args:
+    - '--override_generation_config={"temperature":0.6,"top_p":0.95}' # do not include space
+    - --reasoning-parser=qwen3
+
+generator:
+  temperature: 0.6
+  top_p: 0.95
+  extra_body:
+    chat_template_kwargs:
+      enable_thinking: true
+
+jaster:
+  override_max_tokens: 16384
+
+jtruthfulqa:
+  generator_config:
+    max_tokens: 16384
+
+swebench:
+  max_tokens: 16384
+
+mtbench:
+  max_new_token: 16384
+  temperature_override:
+    writing: 0.6
+    roleplay: 0.6
+    extraction: 0.6
+    math: 0.6
+    coding: 0.6
+    reasoning: 0.6
+    stem: 0.6
+    humanities: 0.6
+
+hallulens:
+  generator_config:
+    max_tokens: 16384
+    temperature: 0.6
+    top_p: 0.95
+
+hle:
+  max_completion_tokens: 16384
+
+arc_agi_2:
+  max_output_tokens: 16384
+
+testmode: true
+run:
+  jaster: true
+  jmmlu_robustness: true # if this is set as true, jaster should set as true
+  mtbench: true
+  jbbq: false
+  toxicity: true
+  jtruthfulqa: true
+  hle: true
+  swebench: true
+  bfcl: false
+  hallulens: true
+  arc_agi_2: true
+  aggregate: false

--- a/configs/config-o4-mini-2025-04-16.yaml
+++ b/configs/config-o4-mini-2025-04-16.yaml
@@ -1,0 +1,70 @@
+wandb:
+  run_name: "openai/o4-mini-2025-04-16" # use run_name defined above
+
+# if you don't use api, please set "api" as "false"
+# if you use api, please select from "openai_responses", "openai_chat", "anthoropic", "google", "cohere", "vllm"
+api: openai_responses
+batch_size: 2 # vllmは256, apiは32を推奨
+# inference_interval: 1 # seconds
+
+model:
+  pretrained_model_name_or_path: "o4-mini-2025-04-16" #if you use openai api, put the name of model
+  size_category: "api"
+  size: null
+  release_date: "4/16/2025"
+
+generator:
+  max_tokens: 131072
+  temperature: 1.0
+  reasoning:
+    effort: "low"
+    summary: "auto"
+
+jaster:
+  override_max_tokens: 131072
+
+jtruthfulqa:
+  generator_config:
+    max_tokens: 131072
+
+swebench:
+  max_tokens: 131072
+
+mtbench:
+  max_new_token: 131072
+  temperature_override:
+    writing: 1.0
+    roleplay: 1.0
+    extraction: 1.0
+    math: 1.0
+    coding: 1.0
+    reasoning: 1.0
+    stem: 1.0
+    humanities: 1.0
+
+hallulens:
+  generator_config:
+    max_tokens: 131072
+    temperature: 1.0
+    top_p: 1.0
+
+hle:
+  max_completion_tokens: 131072
+
+arc_agi_2:
+  max_output_tokens: 131072
+
+testmode: true
+run:
+  jaster: true
+  jmmlu_robustness: true # if this is set as true, jaster should set as true
+  mtbench: true
+  jbbq: false
+  toxicity: true
+  jtruthfulqa: true
+  hle: true
+  swebench: true
+  bfcl: false
+  hallulens: true
+  arc_agi_2: true
+  aggregate: false

--- a/configs/config-o4-mini-2025-04-16.yaml
+++ b/configs/config-o4-mini-2025-04-16.yaml
@@ -23,6 +23,10 @@ generator:
 jaster:
   override_max_tokens: 131072
 
+jbbq:
+  generator_config:
+    max_tokens: 131072
+
 jtruthfulqa:
   generator_config:
     max_tokens: 131072
@@ -59,7 +63,7 @@ run:
   jaster: true
   jmmlu_robustness: true # if this is set as true, jaster should set as true
   mtbench: true
-  jbbq: false
+  jbbq: true
   toxicity: true
   jtruthfulqa: true
   hle: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,17 +1,17 @@
 services:
   vllm:
-    image: vllm/vllm-openai:latest
-    runtime: nvidia
-    # GPU設定はdocker-compose.override.ymlで定義
-    command: >
-      --model ${MODEL_NAME}
-      --dtype ${DTYPE}
-      --max-model-len ${MAX_MODEL_LEN}
-      --served-model-name ${SERVED_MODEL_NAME}
-      --tensor-parallel-size ${TENSOR_PARALLEL_SIZE}
+    # image: vllm/vllm-openai:latest
+    build:
+      context: .
+      dockerfile: Dockerfile.vllm
+      args:
+        VLLM_VERSION: ${VLLM_VERSION:-latest}
     environment:
       - HUGGINGFACE_HUB_TOKEN=${HUGGINGFACE_HUB_TOKEN}
+      - LOCAL_MODEL_PATH=${LOCAL_MODEL_PATH}
+      - EVAL_CONFIG_PATH=${EVAL_CONFIG_PATH}
     volumes:
+      - ./configs:/workspace/configs:ro
       - ~/.cache/huggingface:/root/.cache/huggingface
       - ${LOCAL_MODEL_PATH:-/tmp/empty}:/workspace/models:ro
     ports:

--- a/docker-entrypoint-vllm.sh
+++ b/docker-entrypoint-vllm.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Evaluation configuration path
+if [ -z "$EVAL_CONFIG_PATH" ]; then
+    echo "EVAL_CONFIG_PATH is not set. Please set it to the path of the evaluation configuration file."
+    exit 1
+fi
+echo "EVAL_CONFIG_PATH: ${EVAL_CONFIG_PATH}"
+
+# Model path and name
+served_model_name=$(yq -r '.model.pretrained_model_name_or_path' configs/$EVAL_CONFIG_PATH)
+echo "served_model_name: ${served_model_name}"
+
+if [ -z $LOCAL_MODEL_PATH ]; then
+    model_name=$served_model_name
+    echo "model_name: ${model_name}"
+else
+    model_name=$LOCAL_MODEL_PATH
+    echo "model_name: ${model_name}"
+fi
+
+# Number of GPUs
+num_gpus=$(yq -r '.num_gpus' configs/$EVAL_CONFIG_PATH)
+echo "num_gpus: ${num_gpus}"
+
+# Extra arguments
+extra_args=($(yq -r '.vllm.extra_args[]' configs/$EVAL_CONFIG_PATH))
+echo "extra_args: ${extra_args[@]}"
+
+python3 -m vllm.entrypoints.openai.api_server \
+    --model "${model_name}" \
+    --served-model-name "${served_model_name}" \
+    --tensor-parallel-size "${num_gpus}"\
+    "${extra_args[@]}" \
+    "$@"

--- a/quick_setup.sh
+++ b/quick_setup.sh
@@ -141,15 +141,6 @@ case $model_choice in
         ;;
 esac
 
-# API使用時以外は最大トークン長を設定
-if [ "$USE_API" = false ]; then
-    # 最大トークン長の入力
-    read -p "最大トークン長 [デフォルト: 4096]: " MAX_MODEL_LEN
-    MAX_MODEL_LEN=${MAX_MODEL_LEN:-4096}
-else
-    MAX_MODEL_LEN=4096  # APIの場合はデフォルト値
-fi
-
 # API設定
 if [ "$USE_API" = true ]; then
     echo ""
@@ -305,7 +296,6 @@ else
             fi
             VLLM_GPUS="0,1"
             LEADERBOARD_GPUS="2,3"
-            TENSOR_PARALLEL_SIZE=2
             ;;
         3)
             if [ "$GPU_COUNT" -lt 8 ]; then
@@ -314,7 +304,6 @@ else
             fi
             VLLM_GPUS="0,1,2,3"
             LEADERBOARD_GPUS="4,5,6,7"
-            TENSOR_PARALLEL_SIZE=4
             ;;
         4)
             read -p "vLLM用GPU (カンマ区切り, 例: 0,1): " VLLM_GPUS
@@ -325,7 +314,6 @@ else
         5)
             VLLM_GPUS="0"
             LEADERBOARD_GPUS=""
-            TENSOR_PARALLEL_SIZE=1
             ;;
         *)
             echo "無効な選択です。"
@@ -515,7 +503,6 @@ if [ "$USE_API" = true ]; then
 else
     echo "モード: ローカル/HuggingFace"
     echo "選択されたモデル: $MODEL_NAME"
-    echo "最大トークン長: $MAX_MODEL_LEN"
 fi
 
 echo "WANDB APIキー: [設定済み]"
@@ -617,8 +604,6 @@ cat > "$ENV_FILEPATH" << EOL
 MODEL_NAME=$MODEL_NAME
 SERVED_MODEL_NAME=$MODEL_NAME
 EVAL_CONFIG_PATH=$EVAL_CONFIG_PATH
-DTYPE=half
-MAX_MODEL_LEN=$MAX_MODEL_LEN
 VLLM_PORT=8000
 
 # API Configuration
@@ -680,7 +665,6 @@ if [ "$USE_API" = true ]; then
 else
     echo "モード: ローカル/HuggingFace"
     echo "モデル: $MODEL_NAME"
-    echo "最大トークン長: $MAX_MODEL_LEN"
     echo "vLLM GPU: $VLLM_GPU_IDS (Tensor Parallel: $TENSOR_PARALLEL_SIZE)"
     if [ -n "$LEADERBOARD_GPUS" ]; then
         echo "Leaderboard GPU: $LEADERBOARD_GPU_IDS"

--- a/scripts/evaluator/arc_agi_2.py
+++ b/scripts/evaluator/arc_agi_2.py
@@ -255,6 +255,8 @@ def evaluate():
                         'output': test_example['output'],
                         'prompt': prompt,
                     })
+                if cfg.testmode: # test modeの場合1task1問のみ
+                    break
 
     # Run inference in parallel
     llm_ap = LLMAsyncProcessor(llm=llm, inputs=all_inputs)
@@ -262,7 +264,7 @@ def evaluate():
 
     # Evaluation
     evaluation_results = []
-    for response, task in tqdm(zip(results, tasks)):
+    for response, task in tqdm(zip(results, tasks), total=len(results), desc="Evaluating ARC-AGI-2"):
         raw_output = response.content
         y_pred = backscan_json_parser(raw_output)
 
@@ -285,6 +287,7 @@ def evaluate():
             "prompt": task['prompt'][0]['content'],
             "raw_output": raw_output,
             "input": pretty_print_tile(task['input']),
+            "reasoning_content": response.reasoning_content,
             "output": pretty_print_tile(y_pred) if y_pred is not None else None,
             "expected_output": pretty_print_tile(task['output']),
             "correct": correct,

--- a/scripts/evaluator/hallulens.py
+++ b/scripts/evaluator/hallulens.py
@@ -66,6 +66,8 @@ def evaluate():
     artifact = run.use_artifact(cfg[task_name].artifacts_path, type="dataset")
     artifact_dir = artifact.download()
 
+    generator_config = cfg[task_name].generator_config
+
     for subset in ["test", "dev"]:
         dataset_paths = {
             "refusal_test": f"{subset}/generation.jsonl",
@@ -99,7 +101,6 @@ def evaluate():
 
             # === Prepare inputs for LLM === #
             all_inputs = []
-            generator_config = {"max_tokens": 256, "temperature": 0.0, "top_p": 1.0}
             for sample in samples:
                 messages = [
                     {

--- a/scripts/evaluator/jaster.py
+++ b/scripts/evaluator/jaster.py
@@ -155,7 +155,7 @@ def evaluate_n_shot(few_shots: bool):
                 )
                 
                 # Add inputs only once per sample (for LLM processing)
-                generator_config = {"max_tokens": task_data["output_length"]}
+                generator_config = {"max_tokens": cfg.jaster.override_max_tokens or task_data["output_length"]}
                 inputs.extend([messages, generator_config])
                 
                 for metrics in metrics_list:

--- a/scripts/evaluator/jtruthfulqa.py
+++ b/scripts/evaluator/jtruthfulqa.py
@@ -20,7 +20,7 @@ def load_questions(artifact_dir):
 def generate_answers(questions, llm):
     instance = WandbConfigSingleton.get_instance()
     cfg = instance.config
-    generator_config = {"max_tokens": 256}
+    generator_config = cfg.jtruthfulqa.generator_config
     inputs = [
         ([{"role": "user", "content": '以下の質問に対して50文字以内で回答してください。' + q["Question"][:50]}], generator_config)
         for q in questions
@@ -52,6 +52,8 @@ def evaluate():
     artifact_path = cfg.jtruthfulqa.artifact_path
     artifact_dir = run.use_artifact(artifact_path, type='dataset').download()
     questions = load_questions(artifact_dir)
+    if cfg.testmode:
+        questions = questions[:10]
 
     # vllmサーバーの起動と回答の生成
     answers = generate_answers(questions, llm)

--- a/scripts/llm_inference_adapter.py
+++ b/scripts/llm_inference_adapter.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 from typing import List, Dict, Optional
 import json
 from config_singleton import WandbConfigSingleton
+from omegaconf import OmegaConf, DictConfig
 import openai
 from openai.types.responses import Response as OpenAIResponse
 from openai.types.chat import ChatCompletion as OpenAIChatCompletion
@@ -34,6 +35,8 @@ def map_common_params(params, param_mapping):
     mapped_params = {}
     for key, value in params.items():
         mapped_key = param_mapping.get(key, key)
+        if isinstance(value, DictConfig):
+            value = OmegaConf.to_container(value)
         mapped_params[mapped_key] = value
     return mapped_params
 
@@ -190,10 +193,7 @@ class OpenAIClient:
             'temperature', 'top_p', 'n', 'stream', 'stop', 
             'max_tokens', 'presence_penalty', 'frequency_penalty',
             'logit_bias', 'user', 'response_format', 'seed',
-            'tools', 'tool_choice', 'parallel_tool_calls',
-            # vLLM specific parameters: To be added as needed
-            # https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html#chat-api_1
-            'top_k', 'min_p', 'repetition_penalty', 'length_penalty', 'chat_template_kwargs',
+            'tools', 'tool_choice', 'parallel_tool_calls', 'extra_body',
         }
         
         self.param_mapping = {}

--- a/scripts/llm_inference_adapter.py
+++ b/scripts/llm_inference_adapter.py
@@ -1,9 +1,13 @@
 import os
 import asyncio
 from dataclasses import dataclass
+from abc import ABC, abstractmethod
+from typing import List, Dict, Optional
 import json
 from config_singleton import WandbConfigSingleton
 import openai
+from openai.types.responses import Response as OpenAIResponse
+from openai.types.chat import ChatCompletion as OpenAIChatCompletion
 from mistralai import Mistral
 import google.generativeai as genai
 from anthropic import Anthropic
@@ -17,6 +21,7 @@ from openai import AzureOpenAI
 @dataclass
 class LLMResponse:
     content: str
+    reasoning_content: str = ""
 
 
 def filter_params(params, allowed_params):
@@ -33,7 +38,22 @@ def map_common_params(params, param_mapping):
     return mapped_params
 
 
-class ChatBedrock:
+class BaseLLMClient(ABC):
+    def invoke(self, messages: List[Dict[str, str]], max_tokens: Optional[int] = None, **kwargs) -> LLMResponse:
+        """同期版のinvoke（後方互換性のため）"""
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            return loop.run_until_complete(self.ainvoke(messages, max_tokens, **kwargs))
+        finally:
+            loop.close()
+
+    @abstractmethod
+    async def ainvoke(self, messages: List[Dict[str, str]], max_tokens: Optional[int] = None, **kwargs) -> LLMResponse:
+        raise NotImplementedError
+
+
+class ChatBedrock(BaseLLMClient):
     def __init__(self, cfg) -> None:
         self.bedrock_runtime = boto3.client(
             service_name="bedrock-runtime",
@@ -132,13 +152,7 @@ class ChatBedrock:
         """同期版のinvoke（後方互換性のため）"""
         if max_tokens is None:
             max_tokens = 1024
-        # 同期処理として実行
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            return loop.run_until_complete(self.ainvoke(messages, max_tokens, **kwargs))
-        finally:
-            loop.close()
+        return super().invoke(messages, max_tokens, **kwargs)
 
     async def ainvoke(self, messages, max_tokens=None, **kwargs):
         """非同期版のinvoke"""
@@ -176,19 +190,13 @@ class OpenAIClient:
             'temperature', 'top_p', 'n', 'stream', 'stop', 
             'max_tokens', 'presence_penalty', 'frequency_penalty',
             'logit_bias', 'user', 'response_format', 'seed',
-            'tools', 'tool_choice', 'parallel_tool_calls'
+            'tools', 'tool_choice', 'parallel_tool_calls',
+            # vLLM specific parameters: To be added as needed
+            # https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html#chat-api_1
+            'top_k', 'min_p', 'repetition_penalty', 'length_penalty', 'chat_template_kwargs',
         }
         
         self.param_mapping = {}
-
-    def invoke(self, messages, max_tokens=None, **kwargs):
-        """同期版のinvoke（後方互換性のため）"""
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            return loop.run_until_complete(self.ainvoke(messages, max_tokens, **kwargs))
-        finally:
-            loop.close()
 
     async def ainvoke(self, messages, max_tokens=None, **kwargs):
         """非同期版のinvoke"""
@@ -205,11 +213,61 @@ class OpenAIClient:
         if max_tokens:
             params["max_tokens"] = max_tokens
         
-        response = await self.async_client.chat.completions.create(**params)
-        return LLMResponse(content=response.choices[0].message.content)
+        response: OpenAIChatCompletion = await self.async_client.chat.completions.create(**params)
+        content = response.choices[0].message.content
+        # vLLM reasoning parser output
+        # https://docs.vllm.ai/en/latest/features/reasoning_outputs.html#quickstart
+        reasoning_content = getattr(response.choices[0].message, 'reasoning_content', '')
+        return LLMResponse(content=content, reasoning_content=reasoning_content)
 
 
-class MistralClient:
+class OpenAIResponsesClient(BaseLLMClient):
+    """
+    OpenAIのResponses APIを使用するクライアント(Reasoning対応)
+    """
+    def __init__(self, api_key=None, base_url=None, model=None, **kwargs):
+        self.async_client = openai.AsyncOpenAI(
+            api_key=api_key,
+            base_url=base_url
+        )
+        self.model = model
+        self.kwargs = kwargs
+        
+        self.allowed_params = {
+            'instructions', 'max_output_tokens', 'max_tool_calls', 'metadata',
+            'parallel_tool_calls', 'previous_response_id', 'reasoning', 
+            'service_tier', 'store', 'stream', 'temperature', 'text',
+            'tool_choice', 'tools', 'top_logprobs', 'top_p', 'truncation', 'user',
+        }
+        
+        self.param_mapping = {'max_tokens': 'max_output_tokens', 'top_k': 'top_logprobs'}
+
+    async def ainvoke(self, messages, max_tokens=None, **kwargs):
+        """非同期版のinvoke"""
+        all_kwargs = {**self.kwargs, **kwargs}
+        mapped_params = map_common_params(all_kwargs, self.param_mapping)
+        filtered_params = filter_params(mapped_params, self.allowed_params)
+        
+        params = {
+            "model": self.model,
+            "input": messages,
+            **filtered_params
+        }
+        
+        if max_tokens:
+            params["max_output_tokens"] = max_tokens
+        
+        response: OpenAIResponse = await self.async_client.responses.create(**params)
+        content, reasoning_content = "", ""
+        for output in response.output:
+            if output.type == "message":
+                content = output.content[0].text
+            elif output.type == "reasoning" and len(output.summary) > 0: # reasoning contentは長さ0の場合がある
+                reasoning_content = output.summary[0].text
+        return LLMResponse(content=content, reasoning_content=reasoning_content)
+
+
+class MistralClient(BaseLLMClient):
     def __init__(self, api_key, model, **kwargs):
         self.client = Mistral(api_key=api_key)
         self.model = model
@@ -223,15 +281,6 @@ class MistralClient:
         self.param_mapping = {
             'seed': 'random_seed',
         }
-
-    def invoke(self, messages, max_tokens=None, **kwargs):
-        """同期版のinvoke（後方互換性のため）"""
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            return loop.run_until_complete(self.ainvoke(messages, max_tokens, **kwargs))
-        finally:
-            loop.close()
 
     async def ainvoke(self, messages, max_tokens=None, **kwargs):
         """非同期版のinvoke"""
@@ -253,7 +302,7 @@ class MistralClient:
         return LLMResponse(content=response.choices[0].message.content)
 
 
-class GoogleClient:
+class GoogleClient(BaseLLMClient):
     def __init__(self, api_key, model, **kwargs):
         genai.configure(api_key=api_key)
         self.model = genai.GenerativeModel(model)
@@ -268,15 +317,6 @@ class GoogleClient:
             'max_tokens': 'max_output_tokens',
             'stop': 'stop_sequences',
         }
-
-    def invoke(self, messages, max_tokens=None, **kwargs):
-        """同期版のinvoke（後方互換性のため）"""
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            return loop.run_until_complete(self.ainvoke(messages, max_tokens, **kwargs))
-        finally:
-            loop.close()
 
     async def ainvoke(self, messages, max_tokens=None, **kwargs):
         """非同期版のinvoke"""
@@ -328,7 +368,7 @@ class GoogleClient:
         return LLMResponse(content=response.text)
 
 
-class AnthropicClient:
+class AnthropicClient(BaseLLMClient):
     def __init__(self, api_key, model, **kwargs):
         self.client = Anthropic(api_key=api_key)
         self.model = model
@@ -342,15 +382,6 @@ class AnthropicClient:
         self.param_mapping = {
             'stop': 'stop_sequences',
         }
-
-    def invoke(self, messages, max_tokens=None, **kwargs):
-        """同期版のinvoke（後方互換性のため）"""
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            return loop.run_until_complete(self.ainvoke(messages, max_tokens, **kwargs))
-        finally:
-            loop.close()
 
     async def ainvoke(self, messages, max_tokens=None, **kwargs):
         """非同期版のinvoke"""
@@ -386,7 +417,7 @@ class AnthropicClient:
         return LLMResponse(content=response.content[0].text)
 
 
-class AzureOpenAIClient:
+class AzureOpenAIClient(BaseLLMClient):
     def __init__(self, api_key, azure_endpoint, azure_deployment, api_version, **kwargs):
         self.client = AzureOpenAI(
             api_key=api_key,
@@ -410,15 +441,6 @@ class AzureOpenAIClient:
         
         self.param_mapping = {}
 
-    def invoke(self, messages, max_tokens=None, **kwargs):
-        """同期版のinvoke（後方互換性のため）"""
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            return loop.run_until_complete(self.ainvoke(messages, max_tokens, **kwargs))
-        finally:
-            loop.close()
-
     async def ainvoke(self, messages, max_tokens=None, **kwargs):
         """非同期版のinvoke"""
         all_kwargs = {**self.kwargs, **kwargs}
@@ -438,7 +460,7 @@ class AzureOpenAIClient:
         return LLMResponse(content=response.choices[0].message.content)
 
 
-class CohereClient:
+class CohereClient(BaseLLMClient):
     def __init__(self, api_key, model, **kwargs):
         self.client = cohere.Client(api_key)
         self.model = model
@@ -454,15 +476,6 @@ class CohereClient:
             'top_k': 'k',
             'stop': 'stop_sequences',
         }
-
-    def invoke(self, messages, max_tokens=None, **kwargs):
-        """同期版のinvoke（後方互換性のため）"""
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            return loop.run_until_complete(self.ainvoke(messages, max_tokens, **kwargs))
-        finally:
-            loop.close()
 
     async def ainvoke(self, messages, max_tokens=None, **kwargs):
         """非同期版のinvoke"""
@@ -503,7 +516,7 @@ class CohereClient:
         return LLMResponse(content=response.text)
 
 
-def get_llm_inference_engine():
+def get_llm_inference_engine() -> BaseLLMClient:
     instance = WandbConfigSingleton.get_instance()
     cfg = instance.config
     api_type = cfg.api
@@ -544,7 +557,14 @@ def get_llm_inference_engine():
             **cfg.generator,
         )
 
-    elif api_type == "openai":
+    elif api_type == "openai_responses":
+        llm = OpenAIResponsesClient(
+            api_key=os.environ["OPENAI_API_KEY"],
+            model=cfg.model.pretrained_model_name_or_path,
+            **cfg.generator,
+        )
+
+    elif api_type in ["openai", "openai_chat"]: # "openai" は後方互換性のため
         llm = OpenAIClient(
             api_key=os.environ["OPENAI_API_KEY"],
             model=cfg.model.pretrained_model_name_or_path,


### PR DESCRIPTION
## 概要

Reasoningモデル(vLLM/OpenAI)の対応

## 変更箇所

* llm_inference_adapterにReasoning対応の実装を追加
  * OpenAI Responses APIを使うクライアントを追加
  * OpenAI Chat APIのクライアントにvLLMのreasoning_contentの対応を追加
  * LLMResponseクラスにreasoning_contentを返すプロパティを追加
* vLLMの起動オプションをconfigから読むように変更
  * YAMLを読んで起動オプションを変更するラッパーentrypointスクリプトを追加
  * デフォルトのmax_tokenやdtypeは指定しないほうがvLLMが自動でモデルに合わせてくれるので、extra_argsとして追加引数のみを指定する形式に変更
* Reasoningモデルに対応していないベンチマークの固定推論パラメータをコンフィグ可能に変更
  * hallulens/jaster/jtruthfulqa/jbbqのmax_tokens,temperature,top_pなど
  * o系モデルは短すぎるmax_lenと、1.0以外のtemperatureが通らないため
* 動作確認用のQwen3-14B(reasoning on/off), o4-miniのconfig追加
* その他軽微な修正
  * Dockerfileのビルド順変更(ソース変更時にuv syncとjuman buildが再実行されないようにソースコード追加を後に移動)
  * jtruthfulqaにtestmodeが効いてなかったのを修正

## 未解決(TODO)

* config形式の統一
  * 各ベンチマークで推論パラメータの名前や形式がバラバラなので全部generator_configとかに統一したほうがいいかも？
* 動いていないベンチマーク
  * ~~jbbq(All output format error) -> モデル精度 or サンプリングパラメータの問題？推論自体は動く~~ 直りました
  * bfcl -> 推論クライアントが独自、かつvllm起動方式がin-process vllmに固定されているため
* ARC-AGI以外のoutput_tableにreasoning_contentを追加する

## Run

- o4-mini: https://wandb.ai/llm-leaderboard/nejumi-leaderboard4-dev/runs/tamqu4qs
- Qwen3-14B(reasoning:on): https://wandb.ai/llm-leaderboard/nejumi-leaderboard4-dev/runs/oxe47kov
- Qwen3-14B(reasoning:off): https://wandb.ai/llm-leaderboard/nejumi-leaderboard4-dev/runs/qihd36s8
