### PR TITLE
Add M-IFEval test

### DIFF
--- a/configs/base_config.yaml
+++ b/configs/base_config.yaml
@@ -9,19 +9,19 @@ testmode: true
 inference_interval: 0 # seconds
 
 run:
-  jaster: false
-  jmmlu_robustness: false # if this is set as true, jaster should set as true
-  mtbench: false
-  jbbq: false
-  toxicity: false
-  jtruthfulqa: false
-  hle: false
-  swebench: false
-  bfcl: false
-  hallulens: false
-  arc_agi_2: false
+  jaster: true
+  jmmlu_robustness: true # if this is set as true, jaster should set as true
+  mtbench: true
+  jbbq: true
+  toxicity: true
+  jtruthfulqa: true
+  hle: true
+  swebench: true
+  bfcl: true
+  hallulens: true
+  arc_agi_2: true
   m_ifeval: true
-  aggregate: false
+  aggregate: true
 
 model:
   artifact_path: null

--- a/configs/base_config.yaml
+++ b/configs/base_config.yaml
@@ -162,6 +162,10 @@ arc_agi_2:
   max_output_tokens: 4096
   num_attempts: 2
 
+m_ifeval:
+  artifacts_path: "llm-leaderboard/nejumi-leaderboard4/m_ifeval:production"
+  dataset_dir: "ja_input_data.jsonl"
+
 sample_dataset:
   artifacts_path: "your artifact path here"
   # add necessary configration here

--- a/configs/base_config.yaml
+++ b/configs/base_config.yaml
@@ -9,17 +9,18 @@ testmode: true
 inference_interval: 0 # seconds
 
 run:
-  jaster: true
-  jmmlu_robustness: true # if this is set as true, jaster should set as true
-  mtbench: true
-  jbbq: true
-  toxicity: true
-  jtruthfulqa: true
-  hle: true
-  swebench: true
-  bfcl: true
-  hallulens: true
-  arc_agi_2: true
+  jaster: false
+  jmmlu_robustness: false # if this is set as true, jaster should set as true
+  mtbench: false
+  jbbq: false
+  toxicity: false
+  jtruthfulqa: false
+  hle: false
+  swebench: false
+  bfcl: false
+  hallulens: false
+  arc_agi_2: false
+  m_ifeval: true
   aggregate: false
 
 model:

--- a/requirements.txt
+++ b/requirements.txt
@@ -396,7 +396,7 @@ mypy-extensions==1.1.0
     # via black
 nest-asyncio==1.6.0
     # via outlines
-networkx==3.5
+networkx==3.4.2
     # via torch
 ninja==1.11.1.4
     # via
@@ -964,3 +964,13 @@ zipp==3.23.0
     # via importlib-metadata
 zstandard==0.23.0
     # via langsmith
+absl-py==1.4.0
+datasets
+immutabledict==4.2.1
+janome==0.5.0
+ja_sentence_segmenter==0.0.2
+langdetect==1.0.9
+nltk==3.9.1
+spacy==3.7.5
+bitsandbytes==0.45.1
+hf-transfer==0.1.9

--- a/scripts/evaluator/__init__.py
+++ b/scripts/evaluator/__init__.py
@@ -10,6 +10,7 @@ from . import bfcl
 from . import swebench
 from . import swebench_official
 from . import hallulens
+from . import m_ifeval
 
 __all__ = [
     'jaster',
@@ -23,4 +24,5 @@ __all__ = [
     'swebench',
     'swebench_official',
     'hallulens',
+    'm_ifeval',
 ]

--- a/scripts/evaluator/evaluate_utils/m_ifeval_utils.py
+++ b/scripts/evaluator/evaluate_utils/m_ifeval_utils.py
@@ -1,0 +1,2105 @@
+import dataclasses
+import json
+from typing import Dict, Optional, Union
+
+@dataclasses.dataclass
+class InputExample:
+  key: int
+  instruction_id_list: list[str]
+  prompt: str
+  kwargs: list[Dict[str, Optional[Union[str, int]]]]
+
+
+@dataclasses.dataclass
+class OutputExample:
+  instruction_id_list: list[str]
+  prompt: str
+  response: str
+  follow_all_instructions: bool
+  follow_instruction_list: list[bool]
+
+def read_prompt_list(json_file):
+  """Read inputs from jsonl."""
+  inputs = []
+  for example in json_file:
+      inputs.append(
+          InputExample(key=example["key"],
+                       instruction_id_list=example["instruction_id_list"],
+                       prompt=example["prompt"],
+                       kwargs=example["kwargs"]))
+  return inputs
+
+def read_prompt_to_response_dict(json_file):
+  """Creates dictionary matching prompt and response."""
+  return_dict = {}
+  for example in json_file:
+      return_dict[example["prompt"]] = example["response"]
+  return return_dict
+
+def test_instruction_following_strict(
+    inp,
+    prompt_to_response,
+):
+  """Tests response to see if instrutions are followed."""
+  response = prompt_to_response[inp.prompt]
+  instruction_list = inp.instruction_id_list
+  is_following_list = []
+
+  for index, instruction_id in enumerate(instruction_list):
+    instruction_cls = INSTRUCTION_DICT[instruction_id]
+    instruction = instruction_cls(instruction_id)
+
+    instruction.build_description(**inp.kwargs[index])
+    args = instruction.get_instruction_args()
+    if args and "prompt" in args:
+      instruction.build_description(prompt=inp.prompt)
+
+    if isinstance(response, str) and response.strip() and instruction.check_following(response):
+      is_following_list.append(True)
+    else:
+      is_following_list.append(False)
+
+  return OutputExample(
+      instruction_id_list=inp.instruction_id_list,
+      prompt=inp.prompt,
+      response=response,
+      follow_all_instructions=all(is_following_list),
+      follow_instruction_list=is_following_list,
+  )
+
+
+
+
+####
+
+# coding=utf-8
+# Copyright 2024 The Google Research Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility library of instructions."""
+
+import functools
+import random
+import re
+from typing import List
+
+import immutabledict
+
+from janome.tokenizer import Tokenizer
+
+import functools
+from ja_sentence_segmenter.common.pipeline import make_pipeline
+from ja_sentence_segmenter.concatenate.simple_concatenator import concatenate_matching
+from ja_sentence_segmenter.normalize.neologd_normalizer import normalize
+from ja_sentence_segmenter.split.simple_splitter import split_newline, split_punctuation
+
+WORD_LIST = ["桜", "自転車", "海", "時計", "猫", "本", "雨", "友達", "映画", "音楽"]  # pylint: disable=line-too-long
+
+# ISO 639-1 codes to language names.
+LANGUAGE_CODES = immutabledict.immutabledict({
+    "en": "English",
+    "es": "Spanish",
+    "pt": "Portuguese",
+    "ar": "Arabic",
+    "hi": "Hindi",
+    "fr": "French",
+    "ru": "Russian",
+    "de": "German",
+    "ja": "Japanese",
+    "it": "Italian",
+    "bn": "Bengali",
+    "uk": "Ukrainian",
+    "th": "Thai",
+    "ur": "Urdu",
+    "ta": "Tamil",
+    "te": "Telugu",
+    "bg": "Bulgarian",
+    "ko": "Korean",
+    "pl": "Polish",
+    "he": "Hebrew",
+    "fa": "Persian",
+    "vi": "Vietnamese",
+    "ne": "Nepali",
+    "sw": "Swahili",
+    "kn": "Kannada",
+    "mr": "Marathi",
+    "gu": "Gujarati",
+    "pa": "Punjabi",
+    "ml": "Malayalam",
+    "fi": "Finnish",
+    })
+
+_ALPHABETS = "([A-Za-z])"
+_PREFIXES = "(Mr|St|Mrs|Ms|Dr)[.]"
+_SUFFIXES = "(Inc|Ltd|Jr|Sr|Co)"
+_STARTERS = r"(Mr|Mrs|Ms|Dr|Prof|Capt|Cpt|Lt|He\s|She\s|It\s|They\s|Their\s|Our\s|We\s|But\s|However\s|That\s|This\s|Wherever)"
+_ACRONYMS = "([A-Z][.][A-Z][.](?:[A-Z][.])?)"
+_WEBSITES = "[.](com|net|org|io|gov|edu|me)"
+_DIGITS = "([0-9])"
+_MULTIPLE_DOTS = r"\.{2,}"
+
+
+def split_into_sentences(text):
+  """Split the text into sentences.
+
+  Args:
+    text: A string that consists of more than or equal to one sentences.
+
+  Returns:
+    A list of strings where each string is a sentence.
+  """
+  text = " " + text + "  "
+  text = text.replace("\n", " ")
+  text = re.sub(_PREFIXES, "\\1<prd>", text)
+  text = re.sub(_WEBSITES, "<prd>\\1", text)
+  text = re.sub(_DIGITS + "[.]" + _DIGITS, "\\1<prd>\\2", text)
+  text = re.sub(
+      _MULTIPLE_DOTS,
+      lambda match: "<prd>" * len(match.group(0)) + "<stop>",
+      text,
+  )
+  if "Ph.D" in text:
+    text = text.replace("Ph.D.", "Ph<prd>D<prd>")
+  text = re.sub(r"\s" + _ALPHABETS + "[.] ", " \\1<prd> ", text)
+  text = re.sub(_ACRONYMS + " " + _STARTERS, "\\1<stop> \\2", text)
+  text = re.sub(
+      _ALPHABETS + "[.]" + _ALPHABETS + "[.]" + _ALPHABETS + "[.]",
+      "\\1<prd>\\2<prd>\\3<prd>",
+      text,
+  )
+  text = re.sub(
+      _ALPHABETS + "[.]" + _ALPHABETS + "[.]", "\\1<prd>\\2<prd>", text
+  )
+  text = re.sub(" " + _SUFFIXES + "[.] " + _STARTERS, " \\1<stop> \\2", text)
+  text = re.sub(" " + _SUFFIXES + "[.]", " \\1<prd>", text)
+  text = re.sub(" " + _ALPHABETS + "[.]", " \\1<prd>", text)
+  if "”" in text:
+    text = text.replace(".”", "”.")
+  if '"' in text:
+    text = text.replace('."', '".')
+  if "!" in text:
+    text = text.replace('!"', '"!')
+  if "?" in text:
+    text = text.replace('?"', '"?')
+  text = text.replace(".", ".<stop>")
+  text = text.replace("?", "?<stop>")
+  text = text.replace("!", "!<stop>")
+  text = text.replace("<prd>", ".")
+  sentences = text.split("<stop>")
+  sentences = [s.strip() for s in sentences]
+  if sentences and not sentences[-1]:
+    sentences = sentences[:-1]
+  return sentences
+
+
+def count_sentences(text):
+  """Count the number of sentences."""
+  split_punc2 = functools.partial(split_punctuation, punctuations=r"。!?")
+  concat_tail_no = functools.partial(concatenate_matching, former_matching_rule=r"^(?P<result>.+)(の)$", remove_former_matched=False)
+  segmenter = make_pipeline(normalize, split_newline, concat_tail_no, split_punc2)
+  segmented_sentences = list(segmenter(text))
+  return len(segmented_sentences)
+
+
+def generate_keywords(num_keywords):
+  """Randomly generates a few keywords."""
+  return random.sample(WORD_LIST, k=num_keywords)
+
+def tokenizing_texts(text):
+  """Return tokenized texts"""
+  tokenizer = Tokenizer()
+  return tokenizer.tokenize(text)
+
+
+
+# coding=utf-8
+# Copyright 2024 The Google Research Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Library of instructions."""
+import collections
+import json
+import random
+import re
+import string
+from typing import Dict, Optional, Sequence, Union
+
+from absl import logging
+import langdetect
+
+
+import unicodedata
+
+
+_InstructionArgsDtype = Optional[Dict[str, Union[int, str, Sequence[str]]]]
+
+_LANGUAGES = LANGUAGE_CODES
+
+#The maximum number of kanji letters.
+_KANJI_NUM = 30
+
+#The options of sentence endings.
+_ENDING_LETTERS = ("です", "ます")
+
+#The maximum number of sentences ended with a noun.
+_NOMINAL_ENDING_COUNT = 5
+
+# The relational operation for comparison.
+_COMPARISON_RELATION = ("未満", "以上")
+
+# The maximum number of sentences.
+_MAX_NUM_SENTENCES = 20
+
+# The number of placeholders.
+_NUM_PLACEHOLDERS = 4
+
+# The number of bullet lists.
+_NUM_BULLETS = 5
+
+# The options of constrained response.
+_CONSTRAINED_RESPONSE_OPTIONS = (
+    "はい、そうです。", "いいえ、違います。", "どちらとも言えません。")
+
+# The options of starter keywords.
+_STARTER_OPTIONS = ("私としては、", "私の考えでは、", "私の見解では、",
+                    "個人的には、", "私の意見では、", "私見ですが、", "私の観点から言うと、",
+                    "私の理解では、", "私の視点から見ると、")
+
+# The options of ending keywords.
+# TODO(jeffreyzhou) add more ending options
+_ENDING_OPTIONS = ("他にご質問はありますか？",
+                   "他に何かご不明な点はありますか？",
+                   "他に何かございますか？",
+                   "他にお聞きになりたいことはありますか？")
+
+# The number of highlighted sections.
+_NUM_HIGHLIGHTED_SECTIONS = 4
+
+# The section spliter.
+_SECTION_SPLITER = ("章", "節", "項")
+
+# The number of sections.
+_NUM_SECTIONS = 5
+
+# The number of paragraphs.
+_NUM_PARAGRAPHS = 5
+
+# The postscript marker.
+_POSTSCRIPT_MARKER = ("P.S.", "P.P.S", "追伸")
+
+# The number of keywords.
+_NUM_KEYWORDS = 2
+
+# The occurrences of a single keyword.
+_KEYWORD_FREQUENCY = 3
+
+# The occurrences of a single letter.
+_LETTER_FREQUENCY = 10
+
+# The number of words in the response.
+_NUM_LETTERS_LOWER_LIMIT = 200
+_NUM_LETTERS_UPPER_LIMIT = 1000
+
+
+class Instruction:
+  """An instruction template."""
+
+  def __init__(self, instruction_id):
+    self.id = instruction_id
+
+  def build_description(self, **kwargs):
+    raise NotImplementedError("`build_description` not implemented.")
+
+  def get_instruction_args(self):
+    raise NotImplementedError("`get_instruction_args` not implemented.")
+
+  def get_instruction_args_keys(self):
+    raise NotImplementedError("`get_instruction_args_keys` not implemented.")
+
+  def check_following(self, value):
+    raise NotImplementedError("`check_following` not implemented.")
+
+
+class ResponseLanguageChecker(Instruction):
+  """Check the language of the entire response."""
+
+  def build_description(self, *, language = None):
+    """Build the instruction description.
+
+    Args:
+      language: A string representing the expected language of the response. The
+        language has to comply to the 97 types defined in
+        `langid.py` (https://pypi.org/project/langid/1.1.5/), which follows
+        ISO 639-1 codes (https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes);
+        for example, `en` for English, `zh` for Chinese, `fr` for French.
+
+    Returns:
+      A string representing the instruction description.
+    """
+    self._language = language
+    if self._language is None:
+      self._language = random.choice(list(_LANGUAGES.keys()))
+    # TODO(tianjianlu): opens the description generation to more choices.
+    self._description_pattern = (
+        "あなたは言語「{language}」を用いて応答してください。他の言語は許可されません。")
+    return self._description_pattern.format(language=_LANGUAGES[self._language])
+
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return {"language": self._language}
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return ["language"]
+
+  def check_following(self, value):
+    """Check if the language of the entire response follows the instruction.
+
+    Args:
+      value: A string representing the response.
+
+    Returns:
+      True if the language of `value` follows instruction; otherwise False.
+    """
+    assert isinstance(value, str)
+
+    try:
+      return langdetect.detect(value) == self._language
+    except langdetect.LangDetectException as e:
+      # Count as instruction is followed.
+      logging.error(
+          "Unable to detect language for text %s due to %s", value, e
+      )  # refex: disable=pytotw.037
+      return True
+
+
+class NumberOfSentences(Instruction):
+  """Check the number of sentences."""
+
+  def build_description(self, *, num_sentences = None,
+                        relation = None):
+    """Build the instruction description.
+
+    Args:
+      num_sentences: An integer specifying the number of sentences as a
+        threshold.
+      relation: A string in (`未満`, `以上`), defining the relational
+        operator for comparison.
+        Two relational comparisons are supported for now:
+        if '未満', the actual number of sentences < the threshold;
+        if '以上', the actual number of sentences >= the threshold.
+
+    Returns:
+      A string representing the instruction description.
+    """
+    # The number of sentences as a threshold for comparison.
+    self._num_sentences_threshold = num_sentences
+    if (self._num_sentences_threshold is None or
+        self._num_sentences_threshold < 0):
+      self._num_sentences_threshold = random.randint(1, _MAX_NUM_SENTENCES)
+
+    if relation is None:
+      self._comparison_relation = random.choice(_COMPARISON_RELATION)
+    elif relation not in _COMPARISON_RELATION:
+      raise ValueError("The supported relation for comparison must be in "
+                       f"{_COMPARISON_RELATION}, but {relation} is given.")
+    else:
+      self._comparison_relation = relation
+
+    self._description_pattern = (
+        "応答は{num_sentences}文{relation}の文章で構成させてください。")
+    return self._description_pattern.format(
+        relation=self._comparison_relation,
+        num_sentences=self._num_sentences_threshold)
+
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return {"num_sentences": self._num_sentences_threshold,
+            "relation": self._comparison_relation}
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return ["num_sentences", "relation"]
+
+  def check_following(self, value):
+    """Check if the number of sentences follows the instruction.
+
+    Args:
+      value: A string representing the response.
+
+    Returns:
+      True if the response follows the instruction.
+
+    Raise:
+        ValueError if the string in `instruction_args` is not in
+        [`未満`, `以上`].
+    """
+    num_sentences = count_sentences(value)
+    if self._comparison_relation == _COMPARISON_RELATION[0]:
+      return num_sentences < self._num_sentences_threshold
+    elif self._comparison_relation == _COMPARISON_RELATION[1]:
+      return num_sentences >= self._num_sentences_threshold
+
+
+class PlaceholderChecker(Instruction):
+  """Check the placeholders in template writing."""
+
+  def build_description(self, *, num_placeholders = None):
+    """Build the instruction description.
+
+    Args:
+      num_placeholders: An integer denoting the minimum number of
+        placeholders required in the response.
+
+    Returns:
+      A string representing the instruction description.
+    """
+    self._num_placeholders = num_placeholders
+    if self._num_placeholders is None or self._num_placeholders < 0:
+      self._num_placeholders = random.randint(1, _NUM_PLACEHOLDERS)
+    self._description_pattern = (
+        "応答には少なくとも {num_placeholders} 個のプレースホルダーを含めてください。" +
+        "プレースホルダーは [名前] 、[場所]のように角括弧で表されます。")
+    return self._description_pattern.format(
+        num_placeholders=self._num_placeholders)
+
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return {"num_placeholders": self._num_placeholders}
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return ["num_placeholders"]
+
+  def check_following(self, value):
+    """Check if the number of placeholders follows the instruction.
+
+    Args:
+      value: A string representing the response.
+
+    Returns:
+      True if the actual number of placeholders in the response is greater than
+      or equal to `num_placeholders`; otherwise, False.
+    """
+    placeholders = re.findall(r"\[.*?\]", value)
+    num_placeholders = len(placeholders)
+    return num_placeholders >= self._num_placeholders
+
+
+class BulletListChecker(Instruction):
+  """Checks the bullet list in the prompt."""
+
+  def build_description(self, *, num_bullets = None):
+    """Build the instruction description.
+
+    Args:
+      num_bullets: An integer specifying the exact number of bullet lists
+        that is required to appear in the response.
+
+    Returns:
+      A string representing the instruction description.
+    """
+    self._num_bullets = num_bullets
+    if self._num_bullets is None or self._num_bullets < 0:
+      self._num_bullets = random.randint(1, _NUM_BULLETS)
+    self._description_pattern = (
+        "応答はちょうど {num_bullets} 個の箇条書きで構成してください。 " +
+        "以下のような箇条書きの形を参考にしてください:\n" +
+        "・一つめの内容\n" +
+        "・二つめの内容")
+    return self._description_pattern.format(
+        num_bullets=self._num_bullets)
+
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return {"num_bullets": self._num_bullets}
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return ["num_bullets"]
+
+  def check_following(self, value):
+    r"""Check if the number of bullet lists meets the requirement.
+
+    Args:
+      value: A string representing the response. The response is expected to
+        contain some bullet lists that start with `・`.
+
+    Returns:
+      True if the actual number of bullet lists in the response meets the
+      requirement.
+    """
+    bullet_lists = re.findall(r"^\s*・[^\・].*$", value, flags=re.MULTILINE)
+    num_bullet_lists = len(bullet_lists)
+    return num_bullet_lists == self._num_bullets
+
+
+class NumberedListChecker(Instruction):
+  """Checks the numbered list in the prompt."""
+
+  def build_description(self, *, num_items = None):
+    """Build the instruction description.
+
+    Args:
+      num_bullets: An integer specifying the exact number of numbered lists
+        that is required to appear in the response.
+
+    Returns:
+      A string representing the instruction description.
+    """
+    self._num_items = num_items
+    if self._num_items is None or self._num_items < 0:
+      self._num_items = random.randint(1, _NUM_BULLETS)
+    self._description_pattern = (
+        "応答はちょうど {num_items} 個の番号付きリストで構成してください。 " +
+        "以下のような番号付きリストの形を参考にしてください:\n" +
+        "1. 一つめの内容\n" +
+        "2. 二つめの内容")
+    return self._description_pattern.format(
+        num_items=self._num_items)
+
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return {"num_items": self._num_items}
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return ["num_items"]
+
+  def check_following(self, value):
+    r"""Check if the number of numbered lists meets the requirement.
+
+    Args:
+      value: A string representing the response. The response is expected to
+        contain some numbered lists that start with `1.`.
+
+    Returns:
+      A string representing the instruction description.
+    """
+    numbered_lists = re.findall(r"^\s*\d+\.\s.*$", value, flags=re.MULTILINE)
+    num_numbered_lists = len(numbered_lists)
+    return num_numbered_lists == self._num_items
+  
+
+class ConstrainedResponseChecker(Instruction):
+  """Checks the constrained response."""
+
+  def build_description(self):
+    """Build the instruction description."""
+    # A sequence of string(s) representing the options of the expected response.
+    self._constrained_responses = _CONSTRAINED_RESPONSE_OPTIONS
+    self._description_pattern = ("次の選択肢のいずれかで回答してください: {response_options}")
+    return self._description_pattern.format(
+        response_options=self._constrained_responses)
+
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return None
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return []
+
+  def check_following(self, value):
+    """Checks if the response matches the constrained options.
+
+    Args:
+      value: A string representing the response.
+
+    Returns:
+      True if the actual response contains one of the options in the constrained
+      responses; otherwise False.
+    """
+    value = value.strip()
+    for constrained_response in self._constrained_responses:
+      if constrained_response in value:
+        return True
+    return False
+
+
+class ConstrainedStartChecker(Instruction):
+  """Checks the response start."""
+
+  def build_description(self, *, starter = None):
+    """Build the instruction description.
+
+    Args:
+      starter: A string representing the keyward that the response should start
+        with.
+
+    Returns:
+      A string representing the instruction description.
+    """
+    self._starter = starter.strip() if isinstance(starter, str) else starter
+    if self._starter is None:
+      self._starter = random.choice(_STARTER_OPTIONS)
+    self._description_pattern = ("会話中あなたの番になったら、必ず{starter}で応答を始めてください。")
+    return self._description_pattern.format(starter=self._starter)
+
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return {"starter": self._starter}
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return ["starter"]
+
+  def check_following(self, value):
+    """Checks if the response starts with the constrained keyword or phrase.
+
+    Args:
+      value: A string representing the response.
+
+    Returns:
+      True if the response starts with the given phrase or keyword that is
+      contained in `instruction_args`; otherwise, False.
+    """
+    response_pattern = r"^\s*" + self._starter + r".*$"
+    response_with_constrained_start = re.search(response_pattern, value,
+                                                flags=re.MULTILINE)
+    return True if response_with_constrained_start else False
+
+
+class HighlightSectionChecker(Instruction):
+  """Checks the highlighted section."""
+
+  def build_description(self, *, num_highlights = None):
+    """Build the instruction description.
+
+    Args:
+      num_highlights: An integer specifying the minimum number of highlighted
+        sections.
+
+    Returns:
+      A string representing the instruction description.
+    """
+    self._num_highlights = num_highlights
+    if self._num_highlights is None or self._num_highlights < 0:
+      self._num_highlights = random.randint(1, _NUM_HIGHLIGHTED_SECTIONS)
+
+    self._description_pattern = (
+        "例えば《強調されたセクション》のように、回答の中で少なくとも{num_highlights}つのセクションを《》の記号を用いて強調してください。")
+
+    return self._description_pattern.format(num_highlights=self._num_highlights)
+
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return {"num_highlights": self._num_highlights}
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return ["num_highlights"]
+
+  def check_following(self, value):
+    """Checks if the number of highlighted sections meets the requirement.
+
+    Args:
+      value: a string repesenting the response. The response is expected to
+        contain highlighted sections in the format of *highlighted*.
+
+    Returns:
+      True if the actual number of highlighted sections in the format of
+      《highlighed sections》 meets the minimum requirement; otherwise False.
+    """
+    num_highlights = 0
+    highlights = re.findall(r"《[^\n《》]*》", value)
+    for highlight in highlights:
+      if highlight.strip("《》").strip():
+        num_highlights += 1
+
+    return num_highlights >= self._num_highlights
+
+
+class SectionChecker(Instruction):
+  """Checks the sections."""
+
+  def build_description(self, *, section_spliter = None,
+                        num_sections = None):
+    """Build the instruction description.
+
+    Args:
+      section_spliter: A string represents the section spliter keyword that
+        marks a new section, i.e., `章` or `節`.
+      num_sections: An integer specifying the number of sections.
+
+    Returns:
+      A string representing the instruction description.
+    """
+    self._section_spliter = section_spliter.strip() if isinstance(
+        section_spliter, str) else section_spliter
+    if self._section_spliter is None:
+      self._section_spliter = random.choice(_SECTION_SPLITER)
+
+    self._num_sections = num_sections
+    if self._num_sections is None or self._num_sections < 0:
+      self._num_sections = random.randint(1, _NUM_SECTIONS)
+
+    self._description_pattern = (
+        "あなたは{num_sections}つのセクションで文章を構成させて応答してください。" +
+        "各セクションの始まりは次のように数字と{section_spliter}から書き始めてください。例:\n" +
+        "第1{section_spliter}\n" +
+        "[セクション1の内容]\n" +
+        "第2{section_spliter}\n" +
+        "[セクション2の内容]")
+
+    return self._description_pattern.format(
+        num_sections=self._num_sections,
+        section_spliter=self._section_spliter)
+
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return {"section_spliter": self._section_spliter,
+            "num_sections": self._num_sections}
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return ["section_spliter", "num_sections"]
+
+  def check_following(self, value):
+    """Checks the response contains multiple sections.
+
+    Args:
+      value: A string representing the response. The response is expected
+        to contain multiple sections (number of sections is greater than 1).
+        A new section starts with `第１章`, where the number denotes the
+        section index.
+
+    Returns:
+      True if the number of sections in the response is greater than or equal to
+      the minimum number of sections; otherwise, False.
+    """
+    section_splitter_patten = r"\s?" + r"第[\d\uFF10-\uFF19]+" + self._section_spliter + r"\s?"
+    sections = re.split(section_splitter_patten, value)
+    num_sections = len(sections) - 1
+    return num_sections >= self._num_sections
+
+
+class ParagraphChecker(Instruction):
+  """Checks the paragraphs."""
+
+  def build_description(self, *, num_paragraphs = None):
+    """Build the instruction description.
+
+    Args:
+      num_paragraphs: An integer specifying the number of paragraphs.
+
+    Returns:
+      A string representing the instruction description.
+    """
+    self._num_paragraphs = num_paragraphs
+    if self._num_paragraphs is None or self._num_paragraphs < 0:
+      self._num_paragraphs = random.randint(1, _NUM_PARAGRAPHS)
+
+    self._description_pattern = (
+        "応答は{num_paragraphs}個の段落に分かれた文章で送ってください。それぞれの段落をマークダウンの区切り記号: *** で区切ってください。")
+
+    return self._description_pattern.format(num_paragraphs=self._num_paragraphs)
+
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return {"num_paragraphs": self._num_paragraphs}
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return ["num_paragraphs"]
+
+  def check_following(self, value):
+    """Checks the response contains required number of paragraphs.
+
+    Args:
+      value: A string representing the response. The response may contain
+        paragraphs that are separated by the markdown divider: `***`.
+
+    Returns:
+      True if the actual number of paragraphs is the same as required;
+      otherwise, False.
+    """
+    paragraphs = re.split(r"\s?\*\*\*\s?", value)
+    num_paragraphs = len(paragraphs)
+
+    for index, paragraph in enumerate(paragraphs):
+      if not paragraph.strip():
+        if index == 0 or index == len(paragraphs) - 1:
+          num_paragraphs -= 1
+        else:
+          return False
+
+    return num_paragraphs == self._num_paragraphs
+
+
+class PostscriptChecker(Instruction):
+  """Checks the postscript."""
+
+  def build_description(self, *, postscript_marker = None):
+    """Build the instruction description.
+
+    Args:
+      postscript_marker: A string containing the keyword that marks the start
+        of the postscript section.
+
+    Returns:
+      A string representing the instruction description.
+    """
+    self._postscript_marker = postscript_marker.strip() if isinstance(postscript_marker, str) else postscript_marker
+    if self._postscript_marker is None:
+      self._postscript_marker = random.choice(_POSTSCRIPT_MARKER)
+
+    self._description_pattern = ("応答の最後に、{postscript}で始まる追伸を追加してください。")
+
+
+    return self._description_pattern.format(postscript=self._postscript_marker)
+
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return {"postscript_marker": self._postscript_marker}
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return ["postscript_marker"]
+
+  def check_following(self, value):
+    """Checks if the response follows the postscript format.
+
+    Args:
+      value: a string representing the response. The response is expected to
+        contain a postscript section.
+
+    Returns:
+      True if the response contains a postscript section starting with
+      the keyword containing in the `instruction_args`; otherwise False.
+    """
+    if self._postscript_marker == "P.P.S":
+      postscript_pattern = r"\s*p\.\s?p\.\s?s.*$"
+    elif self._postscript_marker == "P.S.":
+      postscript_pattern = r"\s*p\.\s?s\..*$"
+    else:
+      postscript_pattern = r"\s*" + re.escape(self._postscript_marker) + r".*$"
+    postscript = re.findall(postscript_pattern, value, flags=re.IGNORECASE | re.MULTILINE)
+    return True if postscript else False
+
+
+class RephraseChecker(Instruction):
+  """Checks the repharse."""
+
+  def build_description(self, *, original_message):
+    """Build the instruction description.
+
+    Args:
+      original_message: A string representing the original message. The
+        rephrased response should only change its words/sentences in between
+        its two curly brackets, for example, {change me}. Both original and rephrased
+        messages should contain the changes in the form of {change me}.
+
+    Returns:
+      A string representing the instruction description.
+    """
+    if not self.is_change(original_message):
+      raise ValueError(f"Message {original_message} does not contain changes "
+                       "in the form of {change me}.")
+
+    self._reference_without_change = original_message
+    self._description = ("例えば {ここを変更} のように、元の文章を波括弧で囲まれた部分のみを変更して応答してください")
+
+    return self._description
+
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return {"original_message": self._reference_without_change}
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return ["original_message"]
+
+  def check_following(self, value):
+    r"""Checks if the rephrasing follows the instruction.
+
+    Args:
+      value: A string representing the response, which is expected to rephras
+        the string of `instruction_args`.
+
+    Returns:
+      True if `value` and `instruction_args` only differ by the words/sentences
+      in between two asterisks such as *change me*; otherwise, False.
+    """
+
+    if not self.is_change(value):
+      raise ValueError(f"value {value} does not contain "
+                       "changes in the form of {change me}.")
+
+    response_without_changes = self.strip_changes(value)
+    reference_without_changes = self.strip_changes(
+        self._reference_without_change)
+
+    return response_without_changes == reference_without_changes
+
+  def is_change(self, response):
+    """Check if there is change in the response in the form of *change me*."""
+    return re.search(r"\{.*\}", response)
+
+  def strip_changes(self, response):
+    """Strips off the changes."""
+    return re.sub(r"\{.*\}", "", response)
+
+
+class KeywordChecker(Instruction):
+  """Check the exisitence of certain keywords."""
+
+  def build_description(self, *, keywords = None):
+    """Build the instruction description.
+
+    Args:
+      keywords: A sequence of strings representing the keywords that are
+        expected in the response.
+
+    Returns:
+      A string representing the instruction description.
+    """
+
+    if not keywords:
+      self._keywords = generate_keywords(num_keywords=_NUM_KEYWORDS)
+    else:
+      self._keywords = keywords
+    self._keywords = sorted(self._keywords)
+
+    self._description_pattern = ("応答に次のキーワード {keywords} を含めてください。")
+
+    return self._description_pattern.format(keywords=self._keywords)
+
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return {"keywords": self._keywords}
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return ["keywords"]
+
+  def check_following(self, value):
+    """Check if the response contain the expected keywords."""
+    tokens = tokenizing_texts(value)
+    val_words = [token.surface for token in tokens]
+
+    for keyword in self._keywords:
+      if not keyword in val_words:
+        return False
+    return True
+
+
+class KeywordFrequencyChecker(Instruction):
+  """Check the keyword frequency."""
+
+  def build_description(self, *, keyword = None,
+                        frequency = None,
+                        relation = None):
+    """Build the instruction description.
+
+    Args:
+      keyword: A string representing a keyword that is expected in the response.
+      frequency: An integer specifying the number of times `keyword` is expected
+        to appear in the response.
+      relation: A string in (`未満`, `以上`), defining the relational
+        operator for comparison.
+        Two relational comparisons are supported for now:
+        if '未満', the actual number of occurrences < frequency;
+        if '以上', the actual number of occurrences >= frequency.
+
+    Returns:
+      A string representing the instruction description.
+    """
+    if not keyword:
+      self._keyword = generate_keywords(num_keywords=1)[0]
+    else:
+      self._keyword = keyword.strip()
+
+    self._frequency = frequency
+    if self._frequency is None or self._frequency < 0:
+      self._frequency = random.randint(1, _KEYWORD_FREQUENCY)
+
+    if relation is None:
+      self._comparison_relation = random.choice(_COMPARISON_RELATION)
+    elif relation not in _COMPARISON_RELATION:
+      raise ValueError("The supported relation for comparison must be in "
+                       f"{_COMPARISON_RELATION}, but {relation} is given.")
+    else:
+      self._comparison_relation = relation
+
+    self._description_pattern = (
+        "応答の中で、{keyword} という単語を{frequency}回{relation}出現させてください。")
+
+    return self._description_pattern.format(
+        keyword=self._keyword,
+        relation=self._comparison_relation,
+        frequency=self._frequency)
+
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return {"keyword": self._keyword,
+            "frequency": self._frequency,
+            "relation": self._comparison_relation}
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return ["keyword", "frequency", "relation"]
+
+  def check_following(self, value):
+    """Checks if the response contain the keyword with required frequency."""
+    tokens = tokenizing_texts(value)
+    val_words = [token.surface for token in tokens]
+    dict_val = collections.Counter(val_words)
+    actual_occurrences = dict_val[self._keyword]
+
+    if self._comparison_relation == _COMPARISON_RELATION[0]:
+      return actual_occurrences < self._frequency
+    elif self._comparison_relation == _COMPARISON_RELATION[1]:
+      return actual_occurrences >= self._frequency
+
+
+class NumberOfLetters(Instruction):
+  """Checks the number of letters."""
+
+  def build_description(self, *, num_letters=None, relation=None):
+    """Build the instruction description.
+
+    Args:
+      num_letters: An integer specifying the number of letters contained in the
+        response.
+      relation: A string in (`未満`, `以上`), defining the relational
+        operator for comparison.
+        Two relational comparisons are supported for now:
+        if '未満', the actual number of words < num_words;
+        if '以上', the actual number of words >= num_words.
+
+    Returns:
+      A string representing the instruction description.
+    """
+
+    self._num_letters = num_letters
+    if self._num_letters is None or self._num_letters < 0:
+      self._num_letters = random.randint(
+          _NUM_LETTERS_LOWER_LIMIT, _NUM_LETTERS_UPPER_LIMIT
+      )
+
+    if relation is None:
+      self._comparison_relation = random.choice(_COMPARISON_RELATION)
+    elif relation not in _COMPARISON_RELATION:
+      raise ValueError("The supported relation for comparison must be in "
+                       f"{_COMPARISON_RELATION}, but {relation} is given.")
+    else:
+      self._comparison_relation = relation
+
+    self._description_pattern = (
+        "{num_letters}文字{relation}で答えてください。")
+
+    return self._description_pattern.format(
+        relation=self._comparison_relation,
+        num_letters=self._num_letters)
+
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return {"num_letters": self._num_letters,
+            "relation": self._comparison_relation}
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return ["num_letters", "relation"]
+
+  def check_following(self, value):
+    """Checks if the response contains the expected number of letters."""
+    num_letters = len(value)
+
+    if self._comparison_relation == _COMPARISON_RELATION[0]:
+      return num_letters < self._num_letters
+    elif self._comparison_relation == _COMPARISON_RELATION[1]:
+      return num_letters >= self._num_letters
+
+
+class JsonFormat(Instruction):
+  """Check the Json format."""
+
+  def build_description(self):
+    self._description_pattern = (
+        "マークダウンのバッククォート（```）などを使用して、出力全体をJSON形式で囲んでください。"
+    )
+    return self._description_pattern
+
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return None
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return []
+
+  def check_following(self, value):
+    value = (
+        value.strip()
+        .removeprefix("```json")
+        .removeprefix("```Json")
+        .removeprefix("```JSON")
+        .removeprefix("```")
+        .removesuffix("```")
+        .strip()
+    )
+    try:
+      json.loads(value)
+    except ValueError as _:
+      return False
+    return True
+
+
+class ParagraphFirstWordCheck(Instruction):
+  """Check the paragraph and the first word of the nth paragraph."""
+
+  def build_description(self, num_paragraphs = None,
+                        nth_paragraph = None,
+                        first_word = None):
+    r"""Build the instruction description.
+
+    Args:
+      num_paragraphs: An integer indicating the number of paragraphs expected
+        in the response. A paragraph is a subset of the string that is
+        expected to be separated by '\n\n'.
+      nth_paragraph: An integer indicating the paragraph number that we look at.
+        Note that n starts from 1.
+      first_word: A string that represent the first word of the bth paragraph.
+
+    Returns:
+      A string representing the instruction description.
+    """
+    self._num_paragraphs = num_paragraphs
+    if self._num_paragraphs is None or self._num_paragraphs < 0:
+      self._num_paragraphs = random.randint(1, _NUM_PARAGRAPHS)
+
+    self._nth_paragraph = nth_paragraph
+    if (
+        self._nth_paragraph is None
+        or self._nth_paragraph <= 0
+        or self._nth_paragraph > self._num_paragraphs
+    ):
+      self._nth_paragraph = random.randint(1, self._num_paragraphs + 1)
+
+    self._first_word = first_word
+    if self._first_word is None:
+      self._first_word = generate_keywords(num_keywords=1)[0]
+    self._first_word = self._first_word.lower()
+
+    self._description_pattern = (
+        "{num_paragraphs}個の段落に分けて応答を書いてください。 " +
+        "Pythonだと'\\n\\n'で表されるように、段落はそれぞれ2つの改行で区切ってください。 " +
+        "{nth_paragraph}段落目は「{first_word} 」という単語で書き始めてください。")
+
+    return self._description_pattern.format(
+        num_paragraphs=self._num_paragraphs,
+        nth_paragraph=self._nth_paragraph,
+        first_word=self._first_word)
+
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return {"num_paragraphs": self._num_paragraphs,
+            "nth_paragraph": self._nth_paragraph,
+            "first_word": self._first_word}
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return ["num_paragraphs", "nth_paragraph", "first_word"]
+
+  def check_following(self, value):
+    """Checks for required number of paragraphs and correct first word.
+
+    Args:
+      value: a string representing the response. The response may contain
+        paragraphs that are separated by two new lines and the first word of
+        the nth paragraph will have to match a specified word.
+
+    Returns:
+      True if the number of paragraphs is the same as required and the first
+      word of the specified paragraph is the same as required. Otherwise, false.
+    """
+
+    paragraphs = re.split(r"\n\n", value)
+    num_paragraphs = len(paragraphs)
+
+    for paragraph in paragraphs:
+      if not paragraph.strip():
+        num_paragraphs -= 1
+
+    if self._nth_paragraph <= num_paragraphs:
+      paragraph = paragraphs[self._nth_paragraph - 1].strip()
+      if not paragraph:
+        return False
+    else:
+      return False
+
+    paragraph = paragraph.lstrip("「")
+    paragraph = paragraph.lstrip("『")
+
+    first_word = paragraph[:len(self._first_word)]
+
+    return (
+        num_paragraphs == self._num_paragraphs
+        and first_word == self._first_word
+    )
+
+
+# TODO(jeffrey) add relation - at least/at most?
+class KeySentenceChecker(Instruction):
+  """Check the existence of certain key sentences."""
+
+  def build_description(self, key_sentences = None,
+                        num_sentences = None):
+    """Build the instruction description.
+
+    Args:
+      key_sentences: A sequences of strings representing the key sentences that
+        are expected in the response.
+      num_sentences: The number of key sentences that are expected to be seen in
+        the response.
+
+    Returns:
+      A string representing the instruction description.
+    """
+
+    if not key_sentences:
+      # TODO(jeffrey) make a generate sentences function? wonderwords package
+      self._key_sentences = set(["For now, this is fine."])
+    else:
+      self._key_sentences = key_sentences
+
+    if not num_sentences:
+      self._num_sentences = random.randint(1, len(self._key_sentences))
+    else:
+      self._num_sentences = num_sentences
+
+    self._description_pattern = (
+        "応答には次の文章を{num_sentences}回入れてください：{key_sentences}"
+    )
+
+    return self._description_pattern.format(
+        num_sentences=self._num_sentences, key_sentences=self._key_sentences
+    )
+
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return {"num_sentences": self._num_sentences,
+            "key_sentences": list(self._key_sentences)}
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return ["num_sentences", "key_sentences"]
+
+  def check_following(self, value):
+    """Checks if the response contains the expected key sentences."""
+    count = 0
+    sentences = split_into_sentences(value)
+    for sentence in self._key_sentences:
+      if sentence in sentences:
+        count += 1
+
+    return count == self._num_sentences
+
+
+class ForbiddenWords(Instruction):
+  """Checks that specified words are not used in response."""
+
+  def build_description(self, forbidden_words = None
+                        ):
+    """Build the instruction description.
+
+    Args:
+      forbidden_words: A sequences of strings respresenting words that are not
+        allowed in the response.
+
+    Returns:
+      A string representing the instruction description.
+    """
+
+    if not forbidden_words:
+      self._forbidden_words = generate_keywords(
+          num_keywords=_NUM_KEYWORDS)
+    else:
+      self._forbidden_words = list(set(forbidden_words))
+    self._forbidden_words = sorted(self._forbidden_words)
+    self._description_pattern = (
+        "応答に {forbidden_words} という単語を含めないでください。"
+    )
+
+    return self._description_pattern.format(
+        forbidden_words=self._forbidden_words
+    )
+
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return {"forbidden_words": self._forbidden_words}
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return ["forbidden_words"]
+
+  def check_following(self, value):
+    """Check if the response does not contain the expected keywords."""
+    tokens = tokenizing_texts(value)
+    words = [token.surface for token in tokens]
+    for word in self._forbidden_words:
+      if word in words:
+        return False
+    return True
+
+
+class RephraseParagraph(Instruction):
+  """Checks that the paragraph is rephrased."""
+
+  def build_description(self, *, original_paragraph, low, high
+                        ):
+    """Builds the instruction description.
+
+    Args:
+      original_paragraph: A string presenting the original paragraph. The
+        rephrases response should have betweeb low-high words in common.
+      low: An integer presenting the lower bound of similar words.
+      high: An integer representing the upper bound of similar words.
+
+    Returns:
+      A string representing the instruction description.
+    """
+    # TODO(jeffrey) make more encompassing
+    self._original_paragraph = original_paragraph
+    self._low = low
+    self._high = high
+
+    self._description = (
+      "次の文章を言い換えてください: " +
+      "{original_paragraph}\nあなたの回答には、" +
+      "元の文章に含まれている単語を{low}個から{high}個含める必要があります。" +
+      "単語が同じであるとみなされるのは、すべての文字が同じ場合のみです。" +
+      "例えば、'あめ'と'アメ'と'雨'は異なります。"
+    )
+
+    return self._description.format(original_paragraph=original_paragraph,
+                                    low=self._low, high=self._high)
+
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return {"original_paragraph": self._original_paragraph,
+            "low": self._low,
+            "high": self._high}
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return ["original_paragraph", "low", "high"]
+
+  def check_following(self, value):
+    tokens_value = tokenizing_texts(value)
+    tokens_original = tokenizing_texts(self._original_paragraph)
+    val_words = [token.surface for token in tokens_value if not (token.part_of_speech.startswith('助詞') or token.part_of_speech.startswith('助動詞') or token.part_of_speech.startswith('記号'))]
+    original_words = [token.surface for token in tokens_original if not (token.part_of_speech.startswith('助詞') or token.part_of_speech.startswith('助動詞') or token.part_of_speech.startswith('記号'))]
+
+    dict_val = collections.Counter(val_words)
+    dict_original = collections.Counter(original_words)
+
+    similar_words = 0
+    for word in dict_original:
+      similar_words += min(dict_original[word], dict_val[word])
+
+    return similar_words >= self._low and similar_words <= self._high
+
+
+class TwoResponsesChecker(Instruction):
+  """Check that two responses were given."""
+
+  def build_description(self):
+    """Build the instruction description."""
+    self._description_pattern = (
+        "2種類の異なる答え方をしてください。回答のみを出力し、それぞれの回答はアスタリスク6個（******）で区切ってください。"
+    )
+    return self._description_pattern
+
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return None
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return []
+
+  def check_following(self, value):
+    """Checks if the response has two different answers.
+
+    Args:
+      value: A string representing the response.
+
+    Returns:
+      True if two responses are detected and false otherwise.
+    """
+    valid_responses = list()
+    responses = value.split("******")
+    for index, response in enumerate(responses):
+      if not response.strip():
+        if index != 0 and index != len(responses) - 1:
+          return False
+      else:
+        valid_responses.append(response)
+    return (
+        len(valid_responses) == 2
+        and valid_responses[0].strip() != valid_responses[1].strip()
+    )
+
+
+class RepeatPromptThenAnswer(Instruction):
+  """Checks that Prompt is first repeated then answered."""
+
+  def build_description(self, *, prompt_to_repeat = None):
+    """Build the instruction description.
+
+    Args:
+      prompt_to_repeat: The prompt that is meant to be repeated.
+
+    Returns:
+      A string representing the instruction description.
+    """
+    if not prompt_to_repeat:
+      raise ValueError("prompt_to_repeat must be set.")
+    else:
+      self._prompt_to_repeat = prompt_to_repeat
+    self._description_pattern = (
+        "最初にリクエストを一言一句変えずに繰り返し、その後に答えを述べてください"
+        "（1. 繰り返す前に言葉や文字を追加しないこと; 2. 繰り返すべきリクエストにはこの文を含めないこと）"
+    )
+    return self._description_pattern
+
+  def get_instruction_args(self):
+    """Returns the keyword args of build description."""
+    return {"prompt_to_repeat": self._prompt_to_repeat}
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return ["prompt_to_repeat"]
+
+  def check_following(self, value):
+    if value.strip().startswith(self._prompt_to_repeat.strip()):
+      return True
+    return False
+
+
+class EndChecker(Instruction):
+  """Checks that the prompt ends with a given phrase."""
+
+  def build_description(self, *, end_phrase = None):
+    """Build the instruction description.
+
+    Args:
+      end_phrase: A string representing the phrase the response should end with.
+
+    Returns:
+      A string representing the instruction description.
+    """
+    self._end_phrase = (
+        end_phrase.strip() if isinstance(end_phrase, str) else end_phrase
+    )
+    if self._end_phrase is None:
+      self._end_phrase = random.choice(_ENDING_OPTIONS)
+    self._description_pattern = (
+        "応答の最後に次のフレーズをそのまま出力してください: {ender}。"
+        "このフレーズの後に他の言葉を続けてはいけません。")
+    return self._description_pattern.format(ender=self._end_phrase)
+
+  def get_instruction_args(self):
+    """Returns the keyword args of build description."""
+    return {"end_phrase": self._end_phrase}
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return ["end_phrase"]
+
+  def check_following(self, value):
+    """Checks if the response ends with the expected phrase."""
+    value = value.strip().strip("」』")
+    self._end_phrase = self._end_phrase.strip().strip("」』")
+    return value.endswith(self._end_phrase)
+
+  
+class TitleChecker(Instruction):
+  """Checks the response for a title."""
+
+  def build_description(self):
+    """Build the instruction description."""
+    self._description_pattern = (
+        "例えば『喜びの詩』のように、応答に二重鉤括弧で囲まれたタイトルをつけてください。"
+    )
+    return self._description_pattern
+
+  def get_instruction_args(self):
+    """Returns the keyword args of build description."""
+    return None
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return []
+
+  def check_following(self, value):
+    """Checks if the response contains a title."""
+    pattern = r"『[^\n]+』"
+    re_pattern = re.compile(pattern)
+    titles = re.findall(re_pattern, value)
+
+    for title in titles:
+      if title.lstrip("『").rstrip("』").strip():
+        return True
+    return False
+
+
+class LetterFrequencyChecker(Instruction):
+  """Checks letter frequency."""
+
+  def build_description(self, *, letter = None,
+                        let_frequency = None,
+                        let_relation = None):
+    """Build the instruction description.
+
+    Args:
+      letter: A string representing a letter that is expected in the response.
+      let_frequency: An integer specifying the number of times `keyword` is
+        expected to appear in the response.
+      let_relation: A string in (`未満`, `以上`), defining the
+        relational operator for comparison. Two relational comparisons are
+        supported for now; if '未満', the actual number of
+        occurrences < frequency; if '以上', the actual number of
+        occurrences >= frequency.
+
+    Returns:
+      A string representing the instruction description.
+    """
+    if not letter or len(letter) > 1 or not ('ぁ' <= letter <= 'ん'):
+      self._letter = random.choice([chr(i) for i in range(ord('ぁ'), ord('ん') + 1)])
+    else:
+      self._letter = letter.strip()
+
+    self._frequency = let_frequency
+    if self._frequency is None or self._frequency < 0:
+      self._frequency = random.randint(1, _LETTER_FREQUENCY)
+
+    if let_relation is None:
+      self._comparison_relation = random.choice(_COMPARISON_RELATION)
+    elif let_relation not in _COMPARISON_RELATION:
+      raise ValueError(
+          "The supported relation for comparison must be in "
+          f"{_COMPARISON_RELATION}, but {let_relation} is given."
+      )
+    else:
+      self._comparison_relation = let_relation
+
+    self._description_pattern = (
+        "応答には、文字「{letter}」を{let_frequency}回{let_relation}出現させてください。"
+    )
+
+    return self._description_pattern.format(
+        letter=self._letter,
+        let_frequency=self._frequency,
+        let_relation=self._comparison_relation,
+    )
+
+  def get_instruction_args(self):
+    """Returns the keyword args of build description."""
+    return {"letter": self._letter,
+            "let_frequency": self._frequency,
+            "let_relation": self._comparison_relation}
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return ["letter", "let_frequency", "let_relation"]
+
+  def check_following(self, value):
+    """Checks that the response contains the letter at the right frequency."""
+    letters = collections.Counter(value)
+
+    katakana_letter = chr(ord(self._letter) + 96)
+
+    total_count = letters[self._letter] + letters[katakana_letter]
+
+    if self._comparison_relation == _COMPARISON_RELATION[0]:
+        return total_count < self._frequency
+    else:
+        return total_count >= self._frequency
+  
+
+class PeriodChecker(Instruction):
+  """Checks the response for no periods."""
+
+  def build_description(self):
+    """Build the instruction description."""
+    self._description_pattern = (
+        "応答全体で句点を使用しないでください。"
+    )
+    return self._description_pattern
+
+  def get_instruction_args(self):
+    """Returns the keyword args of build description."""
+    return None
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return []
+
+  def check_following(self, value):
+    """Checks that the response does not contain periods."""
+    return not re.search(r"\。", value)
+
+
+class CommaChecker(Instruction):
+  """Checks the response for no commas."""
+
+  def build_description(self):
+    """Build the instruction description."""
+    self._description_pattern = (
+        "応答全体で読点を使用しないでください。"
+    )
+    return self._description_pattern
+
+  def get_instruction_args(self):
+    """Returns the keyword args of build description."""
+    return None
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return []
+
+  def check_following(self, value):
+    """Checks that the response does not contain commas."""
+    return not re.search(r"\、", value)
+
+
+class QuotationChecker(Instruction):
+  """Checks response is wrapped with quotation marks."""
+
+  def build_description(self):
+    """Build the instruction description."""
+    self._description_pattern = (
+        "応答全体を鉤括弧で囲んでください。"
+    )
+    return self._description_pattern
+
+  def get_instruction_args(self):
+    """Returns the keyword args of build description."""
+    return None
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return []
+
+  def check_following(self, value):
+    """Checks if the response is wrapped with double quotation marks."""
+    value = value.strip()
+    return len(value) > 1 and value[0] == '「' and value[-1] == '」'
+  
+
+class FuriganaForKanji(Instruction):
+  """Checks all kanji is described with furigana."""
+
+  def build_description(self):
+    """Build the instruction description."""
+    self._description_pattern = (
+        "全ての漢字にふりがなをつけてください。ふりがなは全角の括弧（）の中に書いてください。"
+    )
+    return self._description_pattern
+  
+  def get_instruction_args(self):
+    """Returns the keyword args of build description."""
+    return None
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return []
+
+  def check_following(self, value):
+    """Checks if all kanji is described with furigana"""
+    kanji_pattern = r'[\u4e00-\u9faf]+'
+    kanji_with_furigana_pattern = r'[\u4e00-\u9faf]+（[ぁ-ん]+）'
+
+    kanji_count = len(re.findall(kanji_pattern, value))
+    kanji_with_furigana_count = len(re.findall(kanji_with_furigana_pattern, value))
+
+    return kanji_count == kanji_with_furigana_count
+
+
+class KanjiLimit(Instruction):
+  """Check the number of Kanji used in the reponse"""
+
+  def build_description(self, *, kanji_limit=None, relation=None):
+    """Build the instruction description.
+
+    Args:
+      kanji_limit: An integer specifying the number of kanji to be used.
+      relation: A string in (`未満`, `以上`), defining the relational operator for comparison.
+
+    Returns:
+      A string representing the instruction.
+    """
+    self._kanji_limit = kanji_limit
+    if self._kanji_limit is None or self._kanji_limit < 0:
+      self._kanji_limit = random.randint(1, _KANJI_NUM)
+    
+    if relation is None:
+      self._comparison_relation = random.choice(_COMPARISON_RELATION)
+    elif relation not in _COMPARISON_RELATION:
+      raise ValueError("The supported relation for comparison must be in "
+                       f"{_COMPARISON_RELATION}, but {relation} is given.")
+    else:
+      self._comparison_relation = relation
+
+    self._description_pattern = (
+      "{kanji_limit}文字{relation}漢字を用いて、答えてください。") 
+    return self._description_pattern.format(kanji_limit=self._kanji_limit, 
+                                            relation=self._comparison_relation)
+  
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return {"kanji_limit": self._kanji_limit, "relation": self._comparison_relation}
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return ["kanji_limit", "relation"]
+
+  def check_following(self, value):
+    """Checks if the number of kanji used follows the instruction.
+
+    Args:
+      value: A string representing the response.
+
+    Returns:
+      True if the number of kanji used follows the instruction, otherwise False.
+    """
+    kanji_count = len(re.findall(r'[\u4e00-\u9faf]', value))
+    if self._comparison_relation == _COMPARISON_RELATION[0]:
+      return kanji_count < self._kanji_limit
+    elif self._comparison_relation == _COMPARISON_RELATION[1]:
+      return kanji_count >= self._kanji_limit
+
+
+class NoHiragana(Instruction):
+  """Checks no Hiragana"""
+
+  def build_description(self):
+    """Build the instruction description."""
+    self._description_pattern = ("ひらがなを一文字も使わないで答えてください。")
+    return self._description_pattern
+
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return {}
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return []
+
+  def check_following(self, value):
+    """Checks if no hiragana is used."""
+    return not any('ぁ'<=char<='ゖ' for char in value)
+  
+
+class HiraganaOnly(Instruction):
+  """Checks the response written in Hiragana"""
+
+  def build_description(self):
+    """Build the instruction description."""
+    self._description_pattern = ("ひらがなだけを用いて答えてください。")
+    return self._description_pattern
+
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return None
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return []
+
+  def check_following(self, value):
+    """Checks if the response uses only hiragana."""
+    def is_hiragana(char):
+      return 'ぁ' <= char <= 'ん' or char == 'ー'
+
+    def is_ignorable(char):
+      return not unicodedata.category(char).startswith('L')
+
+    return all(is_hiragana(char) or is_ignorable(char) for char in value)
+
+
+class NoKatakana(Instruction):
+  """Checks no Katakana"""
+
+  def build_description(self):
+    """Build the instruction description."""
+    self._description_pattern = ("カタカナを一文字も使わないで答えてください。")
+    return self._description_pattern
+
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return {}
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return []
+
+  def check_following(self, value):
+    """Checks if no katakana is used."""
+    return not any(('ァ'<=char<='ヺ' or 'ｦ'<=char<='ﾟ') for char in value)
+
+
+class KatakanaOnly(Instruction):
+  """Checks the response written in Katakana"""
+
+  def build_description(self):
+    """Build the instruction description."""
+    self._description_pattern = ("カタカナだけを用いて答えてください。")
+    return self._description_pattern
+
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return None
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return []
+
+  def check_following(self, value):
+    """Checks if the response uses only katakana."""
+    def is_katakana(char):
+      return ('ァ' <= char <= 'ン' or
+              char == 'ー' or
+              char == '・' or
+              'ｦ' <= char <= 'ﾟ')
+
+    def is_ignorable(char):
+      return not unicodedata.category(char).startswith('L')
+
+    return all(is_katakana(char) or is_ignorable(char) for char in value)
+
+
+class SentenceEndingUnification(Instruction):
+  """Check all the sentence endings"""
+
+  def build_description(self, *, ending=None):
+    """Build the instruction description.
+      
+    Args:
+      ending: A string used at the end of all sentences.
+    
+    Returns:
+      A string representing the instruction description.
+    """
+    self._ending = ending
+    if self._ending is None:
+        self._ending = random.choice(_ENDING_LETTERS)
+    self._description_pattern = (
+      "応答において、全ての文末が「{ending}」で統一された自然な文章にしてください。")
+    return self._description_pattern.format(ending=self._ending)
+  
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return {"ending": self._ending}
+  
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return ["ending"]
+
+  def check_following(self, value):
+    """Checks if all sentence endings are in the specified form.
+
+    Args:
+      value: A string representing the response.
+
+    Returns:
+      True if all the sentence endings follow the instruction; otherwise False.
+    """
+    quote_pattern_1 = re.compile(r'「.*?」')
+    quote_pattern_2 = re.compile(r'『.*?』')
+    value = re.sub(quote_pattern_1, '', value)
+    value = re.sub(quote_pattern_2, '', value)
+
+    sentences = re.split(r'[。！？]', value)
+    for sentence in sentences:
+      if sentence and not sentence.endswith(self._ending):
+        return False
+    return True
+  
+
+class NominalEndingChecker(Instruction):
+  """Check the nominal endings in the response"""
+
+  def build_description(self, *, count=None):
+    """Build the instruction description.
+
+    Args:
+      count: An integer specifying the exact number of nominal endings
+        that is required to appear in the response.
+    
+    Returns:
+      A string representing the instruction description.
+    """
+    self._count = count 
+    if self._count is None or self._count < 0:
+      self._count = random.randint(1, _NOMINAL_ENDING_COUNT)
+    self._description_pattern = ("応答の中で体言止めを{count}回は使用してください。")
+    return self._description_pattern.format(count = self._count)
+
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return {"count": self._count}
+  
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return ["count"]
+  
+  def check_following(self, value):
+    """Checks if the number of nominal endings meets the requirement.
+
+    Args:
+      value: A string representing the response.
+
+    Returns:
+      True if the actual number of nominal endings meets the minimum requirement; otherwise False.
+    """
+    quote_pattern_1 = re.compile(r'「.*?」')
+    quote_pattern_2 = re.compile(r'『.*?』')
+    value = re.sub(quote_pattern_1, '', value)
+    value = re.sub(quote_pattern_2, '', value)
+
+    tokens = tokenizing_texts(value)
+    tokens = list(tokens)
+
+    noun_count = 0
+    for i in range(1, len(tokens)):
+      if tokens[i].surface in '。！？' and tokens[i-1].part_of_speech.startswith('名詞'):
+        noun_count += 1
+
+    return noun_count >= self._count
+
+
+class KanjiNumberNotationChecker(Instruction):
+  """Check all numbers written in kanji."""
+
+  def build_description(self):
+    """Build the instruction description."""
+    self._description_pattern = "数字を全て漢数字で表記してください。"
+    return self._description_pattern
+
+  def get_instruction_args(self):
+    """Returns the keyward args of `build_description`."""
+    return None
+
+  def get_instruction_args_keys(self):
+    """Returns the args keys of `build_description`."""
+    return []
+  
+  def check_following(self, value):
+    """Checks if all numbers are written in kanji."""
+    return not re.search(r'\d', value)
+
+
+# coding=utf-8
+# Copyright 2024 The Google Research Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+_KEYWORD = "keywords:"
+
+_LANGUAGE = "language:"
+
+_LENGTH = "length_constraints:"
+
+_CONTENT = "detectable_content:"
+
+_FORMAT = "detectable_format:"
+
+_MULTITURN = "multi-turn:"
+
+_COMBINATION = "combination:"
+
+_STARTEND = "startend:"
+
+_CHANGE_CASES = "change_case:"
+
+_PUNCTUATION = "punctuation:"
+
+_LETTERS = "letters:"
+
+_SPECIAL_CHARACTER = "special_character:"
+
+
+JA_INSTRUCTION_DICT = {
+    _KEYWORD + "existence": KeywordChecker,
+    _KEYWORD + "frequency": KeywordFrequencyChecker,
+    # TODO(jeffreyzhou): make a proper set of sentences to choose from
+    # _KEYWORD + "key_sentences": instructions.KeySentenceChecker,
+    _KEYWORD + "forbidden_words": ForbiddenWords,
+    _KEYWORD + "letter_frequency": LetterFrequencyChecker,
+    _LANGUAGE + "response_language": ResponseLanguageChecker,
+    _LENGTH + "number_sentences": NumberOfSentences,
+    _LENGTH + "number_paragraphs": ParagraphChecker,
+    _LENGTH + "number_letters": NumberOfLetters,
+    _LENGTH + "nth_paragraph_first_word": ParagraphFirstWordCheck,
+    _CONTENT + "number_placeholders": PlaceholderChecker,
+    _CONTENT + "postscript": PostscriptChecker,
+    _FORMAT + "number_bullet_lists": BulletListChecker,
+    _FORMAT + "number_numbered_lists": NumberedListChecker,
+    # TODO(jeffreyzhou): Pre-create paragraph or use prompt to replace
+    # _CONTENT + "rephrase_paragraph": instructions.RephraseParagraph,
+    _FORMAT + "constrained_response": ConstrainedResponseChecker,
+    _FORMAT + "number_highlighted_sections": (
+        HighlightSectionChecker),
+    _FORMAT + "multiple_sections": SectionChecker,
+    # TODO(tianjianlu): Re-enable rephrasing with preprocessing the message.
+    # _FORMAT + "rephrase": instructions.RephraseChecker,
+    _FORMAT + "json_format": JsonFormat,
+    _FORMAT + "title": TitleChecker,
+    # TODO(tianjianlu): Re-enable with specific prompts.
+    # _MULTITURN + "constrained_start": instructions.ConstrainedStartChecker,
+    _COMBINATION + "two_responses": TwoResponsesChecker,
+    _COMBINATION + "repeat_prompt": RepeatPromptThenAnswer,
+    _STARTEND + "end_checker": EndChecker,
+    _STARTEND + "sentence_unified_end": SentenceEndingUnification,
+    _FORMAT + "nominal_ending": NominalEndingChecker,
+    _LETTERS + "furigana": FuriganaForKanji,
+    _LETTERS + "kansuuji": KanjiNumberNotationChecker,
+    _LETTERS + "no_katakana": NoKatakana,
+    _LETTERS + "katakana_only": KatakanaOnly,
+    _LETTERS + "no_hiragana": NoHiragana,
+    _LETTERS + "hiragana_only": HiraganaOnly,
+    _LETTERS + "kanji": KanjiLimit,
+    _PUNCTUATION + "no_comma": CommaChecker,
+    _PUNCTUATION + "no_period": PeriodChecker,
+    _STARTEND + "quotation": QuotationChecker,
+}
+
+INSTRUCTION_DICT = {}
+INSTRUCTION_DICT.update({"ja:" + k: v for k, v in JA_INSTRUCTION_DICT.items()})

--- a/scripts/evaluator/m_ifeval.py
+++ b/scripts/evaluator/m_ifeval.py
@@ -1,0 +1,155 @@
+import json
+import time
+from pathlib import Path
+import numpy as np
+import pandas as pd
+from toolz import pipe
+from tqdm import tqdm
+import wandb
+import sys
+import os
+
+from config_singleton import WandbConfigSingleton
+
+
+from .evaluate_utils.m_ifeval_utils import (
+    read_prompt_list,
+    read_prompt_to_response_dict,
+    test_instruction_following_strict,
+)
+from .evaluate_utils import (
+    apply_chat_template,
+    LLMAsyncProcessor,
+)
+
+def evaluate_m_ifeval(input_data, output_data):
+    """M-IFEval 결과를 평가합니다."""
+    
+    instance = WandbConfigSingleton.get_instance()
+    run = instance.run
+    cfg = instance.config
+    
+    # 모델명 추출
+    model_name_safe = cfg.model.pretrained_model_name_or_path.replace('/', '__')
+
+    inputs = read_prompt_list(input_data)
+    prompt_to_response = read_prompt_to_response_dict(output_data)
+    
+    for eval_type, eval_func in [("strict", test_instruction_following_strict)]:
+        print(f"\n=== {eval_type.upper()} 평가 시작 ===")
+        outputs = []
+        for inp in tqdm(inputs, desc=f"{eval_type} 평가 진행"):
+            outputs.append(eval_func(inp, prompt_to_response))
+        
+        # 메트릭 계산 (W&B 로깅용)
+        instruction_total = sum(len(o.instruction_id_list) for o in outputs)
+        instruction_correct = sum(sum(o.follow_instruction_list) for o in outputs)
+        run.log({
+            "m_ifeval_leaderboard_table": wandb.Table(
+                columns=["model_name", "m_ifeval_score"],
+                data=[[model_name_safe, instruction_correct / instruction_total]]
+            )
+        })
+    
+    return instruction_correct / instruction_total
+
+def evaluate():
+    """M-IFEval 평가를 위한 response 생성"""
+    # Retrieve the instance from WandbConfigSingleton and load the W&B run and configuration
+    instance = WandbConfigSingleton.get_instance()
+    run = instance.run
+    cfg = instance.config
+    llm = instance.llm
+
+    model_name_safe = cfg.model.pretrained_model_name_or_path.replace('/', '__')
+
+    # M-IFEval 데이터셋 경로 설정
+    input_data_path = Path("../M-IFEval/data/ja_input_data.jsonl")
+    if not input_data_path.exists():
+        print(f"Input data not found: {input_data_path}")
+        return
+
+    # 입력 데이터 로드
+    input_data = []
+    with open(input_data_path, 'r', encoding='utf-8') as f:
+        for line in f:
+            data = json.loads(line.strip())
+            input_data.append(data)
+
+    # 테스트 모드인 경우 적은 수의 샘플만 처리
+    if cfg.get('testmode', False):
+        input_data = input_data[:5]
+        print(f"테스트 모드: {len(input_data)}개의 샘플만 처리합니다.")
+
+    # 각 프롬프트에 대해 메시지 형식으로 변환
+    evaluation_results = []
+    for idx, data in enumerate(input_data):
+        prompt = data['prompt']
+        
+        # 메시지 형식으로 변환
+        messages = [{"role": "user", "content": prompt}]
+        
+        # generator config 설정
+        generator_config = {"max_tokens": 2048}
+        
+        inputs = [messages, generator_config]
+        
+        # 평가 결과 정보 저장
+        evaluation_results.append({
+            "key": data['key'],
+            "prompt": prompt,
+            "instruction_id_list": data['instruction_id_list'],
+            "kwargs": data['kwargs'],
+            "inputs": inputs,
+            "response": None,  # 나중에 채워질 예정
+        })
+
+    # 모든 입력을 준비
+    all_inputs = [er["inputs"] for er in evaluation_results]
+    
+    print("LLM으로 응답 생성 중...")
+    
+    # LLM으로 응답 생성
+    llm_ap = LLMAsyncProcessor(
+        llm=llm,
+        inputs=all_inputs,
+    )
+    results = llm_ap.get_results()
+    
+    # 결과를 evaluation_results에 저장
+    for response, evaluation_result in tqdm(zip(results, evaluation_results), 
+                                          desc="응답 결과 처리"):
+        evaluation_result["response"] = response
+
+    # 출력 파일 저장
+    output_data = []
+    for er in evaluation_results:
+        # AIMessage 객체에서 텍스트 내용 추출
+        response_text = ""
+        if er["response"]:
+            if hasattr(er["response"], 'content'):
+                response_text = er["response"].content
+            elif isinstance(er["response"], str):
+                response_text = er["response"]
+            else:
+                response_text = str(er["response"])
+        
+        output_data.append({
+            "key": er["key"],
+            "prompt": er["prompt"],
+            "response": response_text,
+            "instruction_id_list": er["instruction_id_list"],
+            "kwargs": er["kwargs"]
+        })
+
+    table_data = [[model_name_safe, data['key'], data['prompt'], data['response'], str(data['instruction_id_list']), str(data['kwargs'])] for data in output_data]
+
+    # log output_data as wandb table
+    run.log({
+        "m_ifeval_output_table": wandb.Table(
+            columns=["model_name", "key", "prompt", "response", "instruction_id_list", "kwargs"],
+            data=table_data
+        )
+    })
+
+    return evaluate_m_ifeval(input_data, output_data)

--- a/scripts/evaluator/m_ifeval.py
+++ b/scripts/evaluator/m_ifeval.py
@@ -64,7 +64,13 @@ def evaluate():
     model_name_safe = cfg.model.pretrained_model_name_or_path.replace('/', '__')
 
     # M-IFEval 데이터셋 경로 설정
-    input_data_path = Path("../M-IFEval/data/ja_input_data.jsonl")
+
+    dataset_name = "m_ifeval"
+    artifact = run.use_artifact(cfg[dataset_name].artifacts_path, type="dataset")
+    artifact_dir = artifact.download()
+    input_data_path = Path(artifact_dir) / cfg[dataset_name].dataset_dir
+    print(f"input_data_path: {input_data_path}")
+    # input_data_path = Path("../M-IFEval/data/ja_input_data.jsonl")
     if not input_data_path.exists():
         print(f"Input data not found: {input_data_path}")
         return

--- a/scripts/evaluator/m_ifeval.py
+++ b/scripts/evaluator/m_ifeval.py
@@ -23,25 +23,25 @@ from .evaluate_utils import (
 )
 
 def evaluate_m_ifeval(input_data, output_data):
-    """M-IFEval 결과를 평가합니다."""
+    """M-IFEval結果を評価します。"""
     
     instance = WandbConfigSingleton.get_instance()
     run = instance.run
     cfg = instance.config
     
-    # 모델명 추출
+    # モデル名抽出
     model_name_safe = cfg.model.pretrained_model_name_or_path.replace('/', '__')
 
     inputs = read_prompt_list(input_data)
     prompt_to_response = read_prompt_to_response_dict(output_data)
     
     for eval_type, eval_func in [("strict", test_instruction_following_strict)]:
-        print(f"\n=== {eval_type.upper()} 평가 시작 ===")
+        print(f"\n=== {eval_type.upper()} 評価開始 ===")
         outputs = []
-        for inp in tqdm(inputs, desc=f"{eval_type} 평가 진행"):
+        for inp in tqdm(inputs, desc=f"{eval_type} 評価実行"):
             outputs.append(eval_func(inp, prompt_to_response))
         
-        # 메트릭 계산 (W&B 로깅용)
+        # メトリクス計算 (W&B ログ用)
         instruction_total = sum(len(o.instruction_id_list) for o in outputs)
         instruction_correct = sum(sum(o.follow_instruction_list) for o in outputs)
         run.log({
@@ -54,7 +54,7 @@ def evaluate_m_ifeval(input_data, output_data):
     return instruction_correct / instruction_total
 
 def evaluate():
-    """M-IFEval 평가를 위한 response 생성"""
+    """M-IFEval評価のためのresponse生成"""
     # Retrieve the instance from WandbConfigSingleton and load the W&B run and configuration
     instance = WandbConfigSingleton.get_instance()
     run = instance.run
@@ -63,7 +63,7 @@ def evaluate():
 
     model_name_safe = cfg.model.pretrained_model_name_or_path.replace('/', '__')
 
-    # M-IFEval 데이터셋 경로 설정
+    # M-IFEvalデータセットパス設定
 
     dataset_name = "m_ifeval"
     artifact = run.use_artifact(cfg[dataset_name].artifacts_path, type="dataset")
@@ -75,62 +75,62 @@ def evaluate():
         print(f"Input data not found: {input_data_path}")
         return
 
-    # 입력 데이터 로드
+    # 入力データロード
     input_data = []
     with open(input_data_path, 'r', encoding='utf-8') as f:
         for line in f:
             data = json.loads(line.strip())
             input_data.append(data)
 
-    # 테스트 모드인 경우 적은 수의 샘플만 처리
+    # テストモードの場合は少数のサンプルのみ処理
     if cfg.get('testmode', False):
         input_data = input_data[:5]
-        print(f"테스트 모드: {len(input_data)}개의 샘플만 처리합니다.")
+        print(f"テストモード: {len(input_data)}個のサンプルのみ処理します。")
 
-    # 각 프롬프트에 대해 메시지 형식으로 변환
+    # 各プロンプトに対してメッセージ形式に変換
     evaluation_results = []
     for idx, data in enumerate(input_data):
         prompt = data['prompt']
         
-        # 메시지 형식으로 변환
+        # メッセージ形式に変換
         messages = [{"role": "user", "content": prompt}]
         
-        # generator config 설정
+        # generator config設定
         generator_config = {"max_tokens": 2048}
         
         inputs = [messages, generator_config]
         
-        # 평가 결과 정보 저장
+        # 評価結果情報保存
         evaluation_results.append({
             "key": data['key'],
             "prompt": prompt,
             "instruction_id_list": data['instruction_id_list'],
             "kwargs": data['kwargs'],
             "inputs": inputs,
-            "response": None,  # 나중에 채워질 예정
+            "response": None,  # 後で埋められる予定
         })
 
-    # 모든 입력을 준비
+    # 全ての入力を準備
     all_inputs = [er["inputs"] for er in evaluation_results]
     
-    print("LLM으로 응답 생성 중...")
+    print("LLMで応答生成中...")
     
-    # LLM으로 응답 생성
+    # LLMで応答生成
     llm_ap = LLMAsyncProcessor(
         llm=llm,
         inputs=all_inputs,
     )
     results = llm_ap.get_results()
     
-    # 결과를 evaluation_results에 저장
+    # 結果をevaluation_resultsに保存
     for response, evaluation_result in tqdm(zip(results, evaluation_results), 
-                                          desc="응답 결과 처리"):
+                                          desc="応答結果処理"):
         evaluation_result["response"] = response
 
-    # 출력 파일 저장
+    # 出力ファイル保存
     output_data = []
     for er in evaluation_results:
-        # AIMessage 객체에서 텍스트 내용 추출
+        # AIMessageオブジェクトからテキスト内容抽出
         response_text = ""
         if er["response"]:
             if hasattr(er["response"], 'content'):

--- a/scripts/run_eval.py
+++ b/scripts/run_eval.py
@@ -18,6 +18,7 @@ from evaluator import (
     jtruthfulqa,
     hle,
     hallulens,
+    m_ifeval,
     aggregate,
     swebench,
     arc_agi_2,
@@ -126,6 +127,10 @@ if cfg.run.hallulens:
 # ARC-AGI-2
 if cfg.run.arc_agi_2:
     arc_agi_2.evaluate()
+
+# M-IFEval
+if cfg.run.m_ifeval:
+    m_ifeval.evaluate()
 
 # Evaluation phase
 if cfg.run.jaster:


### PR DESCRIPTION
**What's Added / Changed**
- Add `scripts/evaluator/m_ifeval.py`
  - Integration logic for running M-IFEval within the existing evaluation framework.
- Add `scripts/evaluator/evaluate_utils/m_ifeval_utils.py`
  - Utility functions for M-IFEval-specific logics.
- Change `requirements.py` for M-IFEval test
  - Added dependencies to support M-IFEval
- Add M-IFEval to `base_config.yaml`, `scripts/evaluator/__init__.py`, `scripts/run_eval.py`.

- origin: https://github.com/lightblue-tech/M-IFEval/tree/main
- result: https://wandb.ai/llm-leaderboard/nejumi-leaderboard4-dev/runs/har2s48h
https://wandb.ai/llm-leaderboard/nejumi-leaderboard4/artifacts/dataset/m_ifeval/v0/usage- dataset: 