### PR TITLE
resample arc-agi-2 and remove json space

### DIFF
--- a/scripts/evaluator/arc_agi_2.py
+++ b/scripts/evaluator/arc_agi_2.py
@@ -37,7 +37,7 @@ PROMPT_TEMPLATE = """\
 
 
 def pretty_print_json(tile: List[List[int]]) -> str:
-    return json.dumps(tile).replace("[[", "[\n  [").replace("]]", "]\n]").replace("], [", "],\n  [")
+    return json.dumps(tile).replace("[[", "[\n  [").replace("]]", "]\n]").replace("], [", "],\n  [").replace(", ", ",")
 
 
 def pretty_print_tile( tile: List[List[int]]) -> str:


### PR DESCRIPTION
* ARC-AGI-2のサンプリング時に8k tokenで収まるサンプルのみ残すように修正
* ARC-AGI-2のJSONのスペースを削除

Qwen3-14B(reasoningなし)でmax 7300くらいになります
https://wandb.ai/llm-leaderboard/nejumi-leaderboard4-dev/runs/jb8o1uwh