### PR TITLE
Add ARC-AGI-1 benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Our evaluation framework incorporates a diverse set of metrics to provide a holi
 | ^ | Code Generation | SWE-bench (full) <br> BFCL (Code Generation) <br> HumanEval-ja (jaster) | | |
 | ^ | Tool Usage | BFCL (Tool Usage) | | |
 | ^ | Instruction Following | M-IFEval | | |
-| ^ | Logical Reasoning | ARC-AGI-2 | | |
+| ^ | Logical Reasoning | ARC-AGI | | |
 | Alignment | Controllability | jaster* (0shot, 2shot)<br> | | |
 | ^ | Ethics/Moral | JCommonsenseMorality*(2shot) | | |
 | ^ | Toxicity || LINE Yahoo Reliability Evaluation Benchmark | This dataset is not publicly available due to its sensitive content.| <TBU> |
@@ -203,8 +203,9 @@ Below, you will find a detailed description of the variables utilized in the `ba
     - `artifact_path`: URL of the WandB Artifact for the HLE-JA dataset.
     - `judge_model`: Model used for judging the generated responses.
 
-- **arc_agi_2:** Settings for the ARC-AGI-2 dataset.
-    - `artifacts_path`: URL of the WandB Artifact for the ARC-AGI-2 dataset.
+- **arc_agi:** Settings for the ARC-AGI dataset.
+    - `arc_agi_1_artifacts_path`: URL of the WandB Artifact for the ARC-AGI-1 dataset.
+    - `arc_agi_2_artifacts_path`: URL of the WandB Artifact for the ARC-AGI-2 dataset.
 
 - **m_ifeval:** Settings for the M-IFEval dataset.
     - `artifacts_path`: URL of the WandB Artifact for the M-IFEval dataset.

--- a/configs/base_config.yaml
+++ b/configs/base_config.yaml
@@ -19,7 +19,7 @@ run:
   swebench: true
   bfcl: true
   hallulens: true
-  arc_agi_2: true
+  arc_agi: true
   m_ifeval: true
   aggregate: true
 
@@ -163,8 +163,9 @@ hle:
     parallel: 32
     params: {} # Currently using OpenAI's default
 
-arc_agi_2:
-  artifacts_path: "llm-leaderboard/nejumi-leaderboard4/arc-agi-2_public-eval_50:production"
+arc_agi:
+  arc_agi_1_artifacts_path: "llm-leaderboard/nejumi-leaderboard4/arc-agi-1_public-eval_50:production"
+  arc_agi_2_artifacts_path: "llm-leaderboard/nejumi-leaderboard4/arc-agi-2_public-eval_50:production"
   max_output_tokens: 4096
   num_attempts: 2
 

--- a/scripts/evaluator/__init__.py
+++ b/scripts/evaluator/__init__.py
@@ -10,7 +10,7 @@ from . import bfcl
 from . import swebench
 from . import swebench_official
 from . import hallulens
-from . import arc_agi_2
+from . import arc_agi
 from . import hle
 from . import m_ifeval
 
@@ -26,7 +26,7 @@ __all__ = [
     'swebench',
     'swebench_official',
     'hallulens',
-    'arc_agi_2',
+    'arc_agi',
     'hle',
     'm_ifeval',
 ]

--- a/scripts/evaluator/aggregate.py
+++ b/scripts/evaluator/aggregate.py
@@ -25,7 +25,7 @@ def update_flag(cfg, blend_cfg):
     mtbench_flag = jbbq_flag  = toxicity_flag = jtruthfulqa_flag = jaster_flag = GLP_flag = ALT_flag = False
     
     # 新しいベンチマークのフラグ
-    arc_agi_2_flag = bfcl_flag = hle_flag = jhumaneval_flag = hallulens_flag = False
+    arc_agi_flag = bfcl_flag = hle_flag = jhumaneval_flag = hallulens_flag = False
     jmmlu_pro_flag = jamc_qa_flag = m_ifeval_flag = False
 
     if hasattr(cfg, 'run'):
@@ -35,7 +35,7 @@ def update_flag(cfg, blend_cfg):
         jtruthfulqa_flag = cfg.run.jtruthfulqa
         jaster_flag = cfg.run.jaster
         swebench_flag = cfg.run.get('swebench', False)
-        arc_agi_2_flag = cfg.run.get('arc_agi_2', False)
+        arc_agi_flag = cfg.run.get('arc_agi', False)
         bfcl_flag = cfg.run.get('bfcl', False)
         hle_flag = cfg.run.get('hle', False)
         hallulens_flag = cfg.run.get('hallulens', False)
@@ -58,8 +58,8 @@ def update_flag(cfg, blend_cfg):
                     jaster_flag = True
                 elif "swebench" in dataset:
                     swebench_flag = True
-                elif "arc_agi_2" in dataset:
-                    arc_agi_2_flag = True
+                elif "arc_agi" in dataset:
+                    arc_agi_flag = True
                 elif "bfcl" in dataset:
                     bfcl_flag = True
                 elif "hle" in dataset:
@@ -76,7 +76,7 @@ def update_flag(cfg, blend_cfg):
     
     # 新しいフラグの追加
     additional_flags = {
-        'arc_agi_2': arc_agi_2_flag,
+        'arc_agi': arc_agi_flag,
         'bfcl': bfcl_flag,
         'hle': hle_flag,
         'jhumaneval': jaster_flag,  # jhuman_evalはjasterの一部
@@ -164,7 +164,7 @@ def create_subcategory_table(run, cfg, category, data_dict, table_name=None):
 
 
 def calculate_glp_scores(cfg, leaderboard_dict, jaster_0shot, jaster_fewshots, mtbench, 
-                        additional_flags, arc_agi_2_result, hle_result, swebench_flag, 
+                        additional_flags, arc_agi_result, hle_result, swebench_flag, 
                         swebench_result, jhumaneval_result, bfcl_result, run):
     """
     汎用的言語性能（GLP）のスコアを階層的に計算
@@ -176,7 +176,7 @@ def calculate_glp_scores(cfg, leaderboard_dict, jaster_0shot, jaster_fewshots, m
        │   ├── 翻訳
        │   └── 情報検索
        ├── 推論能力
-       │   ├── 抽象的推論（ARC-AGI-2）
+       │   ├── 抽象的推論（ARC-AGI）
        │   ├── 論理的推論
        │   └── 数学的推論
        ├── 知識・質問応答
@@ -228,11 +228,12 @@ def calculate_glp_scores(cfg, leaderboard_dict, jaster_0shot, jaster_fewshots, m
     
     # --- 推論能力 ---
     # 抽象的推論
-    if additional_flags.get('arc_agi_2', False) and arc_agi_2_result is not None:
-        leaderboard_dict["GLP_抽象的推論"] = arc_agi_2_result["AVG"][0]
+    if additional_flags.get('arc_agi', False) and arc_agi_result is not None:
+        leaderboard_dict["GLP_抽象的推論"] = arc_agi_result["AVG"][0]
         create_subcategory_table(run, cfg, "abstract_reasoning", {
             "AVG": leaderboard_dict["GLP_抽象的推論"],
-            "arc_agi_2_score": arc_agi_2_result["AVG"][0],
+            "arc-agi-1": arc_agi_result["arc-agi-1"][0],
+            "arc-agi-2": arc_agi_result["arc-agi-2"][0],
         })
     else:
         leaderboard_dict["GLP_抽象的推論"] = float('nan')
@@ -581,7 +582,7 @@ def evaluate():
         jtruthfulqa = read_wandb_table(table_name=f"jtruthfulqa_leaderboard_table", run=run)
 
     # 新しいベンチマークのデータ
-    arc_agi_2_result = load_benchmark_results(run, 'arc_agi_2', "arc_agi_2_leaderboard_table", additional_flags)
+    arc_agi_result = load_benchmark_results(run, 'arc_agi', "arc_agi_leaderboard_table", additional_flags)
     bfcl_result = load_benchmark_results(run, 'bfcl', "bfcl_leaderboard_table", additional_flags)
     # HLEは dev/test で分かれているため、優先順位に従って読み込む
     hle_result = None
@@ -612,7 +613,7 @@ def evaluate():
     if GLP_flag:
         calculate_glp_scores(
             cfg, leaderboard_dict, jaster_0shot, jaster_fewshots, mtbench,
-            additional_flags, arc_agi_2_result, hle_result, swebench_flag,
+            additional_flags, arc_agi_result, hle_result, swebench_flag,
             swebench_result, jhumaneval_result, bfcl_result, run
         )
     

--- a/scripts/run_eval.py
+++ b/scripts/run_eval.py
@@ -23,7 +23,7 @@ from evaluator import (
     m_ifeval,
     aggregate,
     swebench,
-    arc_agi_2,
+    arc_agi,
 )
 from utils import paginate_choices
 
@@ -181,9 +181,9 @@ if cfg.run.bfcl:
 if cfg.run.hallulens:
     hallulens.evaluate()
 
-# ARC-AGI-2
-if cfg.run.arc_agi_2:
-    arc_agi_2.evaluate()
+# ARC-AGI
+if cfg.run.arc_agi:
+    arc_agi.evaluate()
 
 # M-IFEval
 if cfg.run.m_ifeval:


### PR DESCRIPTION
## 修正点

* ARC-AGI-1のベンチマークを追加
  * 2同様にo3の正解率でサンプリング50件
* ARC-AGIカテゴリで1と2の平均をスコアにするように修正

## Run

`testmode:true`, 全データセット: https://wandb.ai/llm-leaderboard/nejumi-leaderboard4-dev/runs/6lq4y01y
`testmode:false`, ARC-AGIのみ全件: https://wandb.ai/llm-leaderboard/nejumi-leaderboard4-dev/runs/ned86lw5