### PR TITLE
move vLLM specific configs from model to vllm section

### DIFF
--- a/configs/base_config.yaml
+++ b/configs/base_config.yaml
@@ -23,33 +23,30 @@ run:
 
 model:
   artifact_path: null
-  ### deprecated: for in-process vllm launch ###
-  max_model_len: 3000
-  chat_template: null
-  dtype: 'float16'
-  trust_remote_code: true
-  device_map: 'auto'
-  load_in_8bit: false
-  load_in_4bit: false
-  ### deprecated ###
 
 vllm: # vLLM server-side launch configuration
-  extra_args: []
   # vLLM docker image tag (default). Override in each model config with `vllm_tag:` or `vllm_docker_image:`
   vllm_tag: latest
   # Volta/Turing など Ampere 未満の GPU で vLLM が Triton MMA カーネルを使ってクラッシュする場合に true に設定
   disable_triton_mma: false
   # vLLMコンテナのライフサイクル管理: auto | always_on | stop_restart
   lifecycle: auto
-  # モデルのデータ型: bfloat16 (推奨), float16, half, auto
-  dtype: bfloat16
-  # example
+  # モデルのデータ型 null の場合はモデル内config.jsonのデフォルト値を使用
+  dtype: null
+  # モデルの最大トークン数 null の場合はモデル内config.jsonのデフォルト値を使用
+  max_model_len: null
+  # モデルのデバイスマップ
+  device_map: null
+  # GPUメモリ使用率制限
+  gpu_memory_utilization: null
+  # Reasoningモデル用のParser設定
+  reasoning_parser: null
+  # HF repository内のリモートコードを信頼するかどうか
+  trust_remote_code: false
+  # 追加のvLLMコマンドライン引数
   # extra_args:
-  #   - --dtype=bfloat16
-  #   - --max_model_len=3000
   #   - '--override_generation_config={"temperature":0.6,"top_p":0.95}' # do not include space
-  #   - --trust_remote_code
-  #   - --reasoning-parser=deepseek_r1
+  extra_args: []
 
 generator: # LLM client default configuration: to be overridden by each benchmark
   top_p: 1.0

--- a/configs/config-example-vllm.yaml
+++ b/configs/config-example-vllm.yaml
@@ -1,29 +1,32 @@
 wandb:
   run_name: "" # name of model
 
-api: "vllm"  # 最もシンプルな指定（推奨）
+api: "vllm-docker"  # 最もシンプルな指定（推奨）
 # base_urlは自動的に "http://vllm:8000/v1" が設定されます
 
 model:
   use_wandb_artifacts: false
   pretrained_model_name_or_path: "" # huggingface model name
   bfcl_model_id:  # find from "llm-leaderboard/scripts/evaluator/evaluate_utils/bfcl_pkg/SUPPORTED_MODELS.md"
-  chat_template: 
-  dtype: 'float16'
   size: # parameter size
   size_category:  # "Small (<10B)", "Medium (10–30B)", "Large (30B+)"
   base_model: "" # base model name such as "llama3.1", "qwen2.5"
   release_date:  # M/DD/YYYY
-  max_model_len: 8192
-  trust_remote_code: true
 
 batch_size: 32
 
 # vLLM server configuration
 vllm:
-  extra_args:
-    - --max-model-len=8192
-    - --trust-remote-code
+  vllm_tag: latest
+  lifecycle: auto
+  # 以下はモデルにより調整が必要な場合のみ設定
+  # disable_triton_mma: false
+  # dtype: bfloat16
+  # max_model_len: 8192
+  # device_map: auto
+  # gpu_memory_utilization: 0.95
+  # reasoning_parser: deepseek_r1
+  # trust_remote_code: false
 
 # Number of GPUs for tensor parallelism
 num_gpus: 1 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
       # VLLM Configuration
       - VLLM_ENDPOINT=vllm
       - VLLM_PORT=8000
-      - VLLM_API_KEY=${VLLM_API_KEY}
+      - VLLM_API_KEY=${VLLM_API_KEY:-EMPTY} # 空文字列を入れるとリクエストエラーになる
       - OPENAI_COMPATIBLE_API_KEY=${OPENAI_COMPATIBLE_API_KEY}
 
       # AWS Configuration (optional)

--- a/docker-entrypoint-vllm.sh
+++ b/docker-entrypoint-vllm.sh
@@ -19,46 +19,69 @@ else
     echo "model_name: ${model_name}"
 fi
 
-# Number of GPUs
-num_gpus=$(yq -r '.num_gpus' configs/$EVAL_CONFIG_PATH)
-echo "num_gpus: ${num_gpus}"
-
-# Extra arguments
-extra_args=($(yq -r '.vllm.extra_args[]' configs/$EVAL_CONFIG_PATH))
-echo "extra_args: ${extra_args[@]}"
-
-# 追加パラメータ
-max_model_len=$(yq -r '.model.max_model_len' configs/$EVAL_CONFIG_PATH)
-[ "$max_model_len" == "null" ] && max_model_len=8192
-echo "max_model_len: ${max_model_len}"
-
-dtype=$(yq -r '.vllm.dtype' configs/$EVAL_CONFIG_PATH)
-[ "$dtype" == "null" ] && dtype="half"
-echo "dtype: ${dtype}"
-
-disable_triton_mma=$(yq -r '.vllm.disable_triton_mma' configs/$EVAL_CONFIG_PATH)
-echo "disable_triton_mma: ${disable_triton_mma}"
-
 # Build vLLM command arguments
 vllm_args=(
     "--model" "${model_name}"
     "--served-model-name" "${served_model_name}"
-    "--dtype" "${dtype}"
-    "--max-model-len" "${max_model_len}"
 )
 
+# Number of GPUs
+num_gpus=$(yq -r '.num_gpus' configs/$EVAL_CONFIG_PATH)
 # Add tensor-parallel-size only if num_gpus is set and not null
 if [ ! -z "$num_gpus" ] && [ "$num_gpus" != "null" ]; then
     vllm_args+=("--tensor-parallel-size" "${num_gpus}")
 fi
+echo "num_gpus: ${num_gpus}"
+
+# 追加パラメータ
+max_model_len=$(yq -r '.vllm.max_model_len' configs/$EVAL_CONFIG_PATH)
+if [ ! -z "$max_model_len" ] && [ "$max_model_len" != "null" ]; then
+    vllm_args+=("--max-model-len" "${max_model_len}")
+fi
+echo "max_model_len: ${max_model_len}"
+
+dtype=$(yq -r '.vllm.dtype' configs/$EVAL_CONFIG_PATH)
+if [ ! -z "$dtype" ] && [ "$dtype" != "null" ]; then
+    vllm_args+=("--dtype" "${dtype}")
+fi
+echo "dtype: ${dtype}"
+
+device_map=$(yq -r '.vllm.device_map' configs/$EVAL_CONFIG_PATH)
+if [ ! -z "$device_map" ] && [ "$device_map" != "null" ]; then
+    vllm_args+=("--device" "${device_map}")
+fi
+echo "device_map: ${device_map}"
+
+gpu_memory_utilization=$(yq -r '.vllm.gpu_memory_utilization' configs/$EVAL_CONFIG_PATH)
+if [ ! -z "$gpu_memory_utilization" ] && [ "$gpu_memory_utilization" != "null" ]; then
+    vllm_args+=("--gpu-memory-utilization" "${gpu_memory_utilization}")
+fi
+echo "gpu_memory_utilization: ${gpu_memory_utilization}"
+
+reasoning_parser=$(yq -r '.vllm.reasoning_parser' configs/$EVAL_CONFIG_PATH)
+if [ ! -z "$reasoning_parser" ] && [ "$reasoning_parser" != "null" ]; then
+    vllm_args+=("--reasoning-parser" "${reasoning_parser}")
+fi
+echo "reasoning_parser: ${reasoning_parser}"
+
+trust_remote_code=$(yq -r '.vllm.trust_remote_code' configs/$EVAL_CONFIG_PATH)
+if [ "$trust_remote_code" == "true" ]; then
+    vllm_args+=("--trust-remote-code")
+fi
+echo "trust_remote_code: ${trust_remote_code}"
+
+disable_triton_mma=$(yq -r '.vllm.disable_triton_mma' configs/$EVAL_CONFIG_PATH)
+echo "disable_triton_mma: ${disable_triton_mma}"
 
 # Triton MMA を無効にする場合
 if [ "$disable_triton_mma" == "true" ]; then
     export VLLM_DISABLE_TRITON_MMA=1
 fi
 
-# Add extra arguments
+# Extra arguments
+extra_args=($(yq -r '.vllm.extra_args[]' configs/$EVAL_CONFIG_PATH))
 vllm_args+=("${extra_args[@]}")
+echo "extra_args: ${extra_args[@]}"
 
 # Add any additional arguments passed to the script
 vllm_args+=("$@")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "bitsandbytes==0.45.1",
     "boto3>=1.38.36", # 重複だが上位互換で統一
     "botocore>=1.38.36",
-    "cohere>=5.15.0", # より新しい方に統一
+    "cohere~=5.15.0", # より新しい方に統一
     "datamodel-code-generator==0.25.7",
     "datasets",
     "fuzzywuzzy>=0.18.0",

--- a/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/model_handler/local_inference/base_oss_handler.py
+++ b/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/model_handler/local_inference/base_oss_handler.py
@@ -35,7 +35,7 @@ class OSSHandler(BaseHandler, EnforceOverrides):
         self.model_path_or_id = cfg.model.pretrained_model_name_or_path
 
         # Read from env vars with fallbacks
-        if cfg.api == "vllm":
+        if cfg.api in ["vllm", "vllm-docker"]:
             self.base_url = "http://vllm:8000/v1"
             self.client = OpenAI(base_url=self.base_url, api_key="EMPTY")
         elif cfg.api == "openai-compatible":

--- a/scripts/vllm_server.py
+++ b/scripts/vllm_server.py
@@ -184,18 +184,18 @@ def start_vllm_server():
                 "python3", "-m", "vllm.entrypoints.openai.api_server",
                 "--model", str(model_path),
                 "--served-model-name", model_id,
-                "--dtype", cfg.model.dtype, 
+                "--dtype", cfg.vllm.dtype,
                 "--chat-template", chat_template_path,
-                "--max-model-len", str(cfg.model.max_model_len),
+                "--max-model-len", str(cfg.vllm.max_model_len),
                 "--max-num-seqs", str(cfg.batch_size),
                 "--tensor-parallel-size", str(cfg.get("num_gpus", 1)),
-                "--device", cfg.model.device_map,
+                "--device", cfg.vllm.device_map,
                 "--seed", "42",
                 "--uvicorn-log-level", "warning",
                 "--disable-log-stats",
                 "--disable-log-requests",
                 "--revision", str(cfg.get("revision", 'main')),
-                "--gpu-memory-utilization", str(cfg.get("gpu_memory_utilization", 0.9)),
+                "--gpu-memory-utilization", str(cfg.vllm.get("gpu_memory_utilization", 0.9)),
                 "--port", str(port),
             ]
 
@@ -231,7 +231,7 @@ def start_vllm_server():
                 if lora_config.fully_sharded_loras:
                     command.append("--fully-sharded-loras")
                     
-            if cfg.model.trust_remote_code:
+            if cfg.vllm.trust_remote_code:
                 command.append("--trust-remote-code")
 
             print(command)

--- a/uv.lock
+++ b/uv.lock
@@ -438,7 +438,7 @@ wheels = [
 
 [[package]]
 name = "cohere"
-version = "5.16.1"
+version = "5.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastavro" },
@@ -451,9 +451,9 @@ dependencies = [
     { name = "types-requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/c7/fd1e4c61cf3f0aac9d9d73fce63a766c9778e1270f7a26812eb289b4851d/cohere-5.16.1.tar.gz", hash = "sha256:02aa87668689ad0fbac2cda979c190310afdb99fb132552e8848fdd0aff7cd40", size = 162300, upload-time = "2025-07-09T20:47:36.348Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/33/69c7d1b25a20eafef4197a1444c7f87d5241e936194e54876ea8996157e6/cohere-5.15.0.tar.gz", hash = "sha256:e802d4718ddb0bb655654382ebbce002756a3800faac30296cde7f1bdc6ff2cc", size = 135021, upload-time = "2025-04-15T13:39:51.404Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/c6/72309ac75f3567425ca31a601ad394bfee8d0f4a1569dfbc80cbb2890d07/cohere-5.16.1-py3-none-any.whl", hash = "sha256:37e2c1d69b1804071b5e5f5cb44f8b74127e318376e234572d021a1a729c6baa", size = 291894, upload-time = "2025-07-09T20:47:34.919Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/87/94694db7fe6df979fbc03286eaabdfa98f1c8fa532960e5afdf965e10960/cohere-5.15.0-py3-none-any.whl", hash = "sha256:22ff867c2a6f2fc2b585360c6072f584f11f275ef6d9242bac24e0fa2df1dfb5", size = 259522, upload-time = "2025-04-15T13:39:49.498Z" },
 ]
 
 [[package]]
@@ -2415,7 +2415,7 @@ requires-dist = [
     { name = "bitsandbytes", specifier = "==0.45.1" },
     { name = "boto3", specifier = ">=1.38.36" },
     { name = "botocore", specifier = ">=1.38.36" },
-    { name = "cohere", specifier = ">=5.15.0" },
+    { name = "cohere", specifier = "~=5.15.0" },
     { name = "datamodel-code-generator", specifier = "==0.25.7" },
     { name = "datasets" },
     { name = "docker", specifier = ">=6.0.0" },
@@ -2597,7 +2597,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.5.1.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/78/4535c9c7f859a64781e43c969a3a7e84c54634e319a996d43ef32ce46f83/nvidia_cudnn_cu12-9.5.1.17-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:30ac3869f6db17d170e0e556dd6cc5eee02647abc31ca856634d5a40f82c15b2", size = 570988386, upload-time = "2024-10-25T19:54:26.39Z" },
@@ -2608,7 +2608,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/16/73727675941ab8e6ffd86ca3a4b7b47065edcca7a997920b831f8147c99d/nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ccba62eb9cef5559abd5e0d54ceed2d9934030f51163df018532142a8ec533e5", size = 200221632, upload-time = "2024-11-20T17:41:32.357Z" },
@@ -2637,9 +2637,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/6e/c2cf12c9ff8b872e92b4a5740701e51ff17689c4d726fca91875b07f655d/nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e9e49843a7707e42022babb9bcfa33c29857a93b88020c4e4434656a655b698c", size = 158229790, upload-time = "2024-11-20T17:43:43.211Z" },
@@ -2651,7 +2651,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/06/1e/b8b7c2f4099a37b96af5c9bb158632ea9e5d9d27d7391d7eb8fc45236674/nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7556d9eca156e18184b94947ade0fba5bb47d69cec46bf8660fd2c71a4b48b73", size = 216561367, upload-time = "2024-11-20T17:44:54.824Z" },
@@ -4324,20 +4324,6 @@ dependencies = [
     { name = "fsspec", version = "2025.3.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
     { name = "jinja2", marker = "sys_platform != 'linux'" },
     { name = "networkx", marker = "sys_platform != 'linux'" },
-    { name = "nvidia-cublas-cu12", marker = "python_version < '0'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "python_version < '0'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "python_version < '0'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "python_version < '0'" },
-    { name = "nvidia-cudnn-cu12", marker = "python_version < '0'" },
-    { name = "nvidia-cufft-cu12", marker = "python_version < '0'" },
-    { name = "nvidia-cufile-cu12", marker = "python_version < '0'" },
-    { name = "nvidia-curand-cu12", marker = "python_version < '0'" },
-    { name = "nvidia-cusolver-cu12", marker = "python_version < '0'" },
-    { name = "nvidia-cusparse-cu12", marker = "python_version < '0'" },
-    { name = "nvidia-cusparselt-cu12", marker = "python_version < '0'" },
-    { name = "nvidia-nccl-cu12", marker = "python_version < '0'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "python_version < '0'" },
-    { name = "nvidia-nvtx-cu12", marker = "python_version < '0'" },
     { name = "sympy", marker = "sys_platform != 'linux'" },
     { name = "typing-extensions", marker = "sys_platform != 'linux'" },
 ]
@@ -4548,7 +4534,7 @@ name = "triton"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "setuptools", marker = "sys_platform == 'linux'" },
+    { name = "setuptools", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/21/2f/3e56ea7b58f80ff68899b1dbe810ff257c9d177d288c6b0f55bf2fe4eb50/triton-3.3.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b31e3aa26f8cb3cc5bf4e187bf737cbacf17311e1112b781d4a059353dfd731b", size = 155689937, upload-time = "2025-05-29T23:39:44.182Z" },
@@ -5017,8 +5003,8 @@ name = "xformers"
 version = "0.0.31"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'linux'" },
-    { name = "torch", version = "2.7.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "numpy", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
+    { name = "torch", version = "2.7.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/35/91c172a57681e1c03de5ad1ca654dc87c282279b941052ed04e616ae5bcd/xformers-0.0.31.tar.gz", hash = "sha256:3fccb159c6327c13fc1b08f8b963c2779ca526e2e50755dee9bcc1bac67d20c6", size = 12102740, upload-time = "2025-06-25T15:12:10.241Z" }
 wheels = [


### PR DESCRIPTION
## 変更点

* vllm configの変更
  * model sectionのうちmetadata的なものを残して、vLLMの起動設定に関するものをvllmセクションに移動
  * vllmの max_model_len / dtype をデフォルト未指定にして config.jsonのパラメータが優先されるように変更
  * vLLMでよく使う設定値を追加
  * vllmのexample configを上記に合わせて修正
  * 念の為ローカルvLLM起動パスも上記の変更に対応
* 細かいfix
　　* coreheのバージョンアップでimport errorになるのでバージョンを固定
　　* BFCLでvllm-dockerを指定するとエラーになるので許可API Typeを追加
　　* VLLM_API_KEYに空環境変数を入れるとリクエストエラーになるためデフォルト値をcomposeに設定

## Run

https://wandb.ai/llm-leaderboard/nejumi-leaderboard4-dev/runs/2o5z14p3