### PR TITLE
Fix API error retry handling for temporary errors

### DIFF
--- a/configs/base_config.yaml
+++ b/configs/base_config.yaml
@@ -1,6 +1,6 @@
 wandb:
   entity: 'llm-leaderboard'
-  project: 'nejumi-leaderboard4-bfcl-test'
+  project: 'nejumi-leaderboard4'
   #run: please set up run name in a model-base config
 
 testmode: true

--- a/configs/config-xai-grok-3.yaml
+++ b/configs/config-xai-grok-3.yaml
@@ -1,0 +1,12 @@
+wandb:
+  run_name: grok-3
+api: xai # openai, anthropic, google,..
+batch_size: 8
+model:
+  pretrained_model_name_or_path: grok-3 #if you use openai api, put the name of model
+  bfcl_model_id: grok-3-beta-FC  # find id from "llm-leaderboard/scripts/evaluator/evaluate_utils/bfcl_pkg/SUPPORTED_MODELS.md"
+  base_model: unknown
+  size_category: api
+  size: null
+  release_date: "2/19/2025"
+

--- a/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/model_handler/api_inference/grok.py
+++ b/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/model_handler/api_inference/grok.py
@@ -10,9 +10,19 @@ class GrokHandler(OpenAICompletionsHandler):
         super().__init__(model_name, temperature)
         self.client = OpenAI(
             base_url="https://api.x.ai/v1",
-            api_key=os.getenv("GROK_API_KEY"),
+            api_key=os.getenv("XAI_API_KEY"),
         )
         self.is_fc_model = "FC" in self.model_name
+
+    def _add_reasoning_content_if_available(self, api_response: any, response_data: dict) -> None:
+        """
+        Grok models support reasoning content in the API response.
+        This method delegates to the appropriate method based on whether the model is FC or prompting.
+        """
+        if self.is_fc_model:
+            self._add_reasoning_content_if_available_FC(api_response, response_data)
+        else:
+            self._add_reasoning_content_if_available_prompting(api_response, response_data)
 
     @override
     def _parse_query_response_prompting(self, api_response: any) -> dict:


### PR DESCRIPTION
### 問題
- Toxicity評価において、`PermissionDeniedError`でリトライしてしまう。
- Grok用ハンドラーに必要なメソッドが足りなかった。

### 修正内容
- `PermissionDeniedError`をバックオフから外してモデルプロバイダーからのエラーメッセージを結果として扱うように。他の永続的なエラーでは停止するように。一時的なエラーでは従来通りリトライするように修正。
- Grokハンドラーに`_add_reasoning_content_if_available`メソッドを追加

**主な変更点:**
- 一時的エラーのみを明示的にbackoffの対象として列挙
- 永続的エラーは対象外とし、リトライせずに上位に例外を伝播

### 動作
- **一時的エラー** (`RateLimitError`, `InternalServerError`等): リトライされる
- **PermissionDeniedError**: リトライされず、Toxicity評価でのみ結果として処理、他の評価タスクではエラーで停止
- **その他の永続的エラー** (`AuthenticationError`等): リトライされず、エラーで停止

### 影響範囲
- **全評価タスク**: 一時的なAPIエラーが適切にリトライされ、評価の安定性が向上
- **Toxicity評価**: ガードレールエラーは引き続き結果として扱われる
- **認証エラー等**: 適切にエラーで停止し、問題を早期発見できる

### テスト
- [gpt-4o-mini](https://wandb.ai/llm-leaderboard/nejumi-leaderboard4/runs/hhtec77q)
- [grok-3](https://wandb.ai/llm-leaderboard/nejumi-leaderboard4/runs/mz5g277j)