### PR TITLE
Bfcl openrouter improvement

### DIFF
--- a/configs/base_config.yaml
+++ b/configs/base_config.yaml
@@ -148,12 +148,9 @@ mtbench:
       temperature: 0.0
 
 bfcl:
-  test_category: "java javascript live_irrelevance live_multiple live_parallel_multiple live_parallel live_relevance live_simple multi_turn_base multi_turn_miss_func multi_turn_miss_param simple multiple irrelevance parallel parallel_multiple"  # multi_turn_long_context以外のカテゴリを指
-  temperature: 0.01  # 推論共通化未対応のHandler用: 移行終わったら消す
-  generator_config:  # 推論共通化後のHandler用
-    max_tokens: 4096
-    temperature: 0.01
-  num_threads: 8
+  test_category: "java javascript live_irrelevance live_multiple live_parallel_multiple live_parallel live_relevance live_simple multi_turn_base multi_turn_miss_func multi_turn_miss_param simple multiple irrelevance parallel parallel_multiple"  # multi_turn_long_context以外のカテゴリを指定
+  temperature: 0.01  # 推論共通化未対応のHandler用
+  num_threads: 2
   artifacts_path: 'llm-leaderboard/nejumi-leaderboard4/bfcl:production'
 
 hallulens:

--- a/configs/config-example-openai-compatible.yaml
+++ b/configs/config-example-openai-compatible.yaml
@@ -2,18 +2,25 @@ wandb:
   run_name: "example-openai-compatible"
 
 api: "openai-compatible"
-base_url: "https://your-api-endpoint.com/v1"  # 外部APIのエンドポイント
+base_url: "https://openrouter.ai/api/v1"  # 外部APIのエンドポイント。値はOpenrouterを例としている
 batch_size: 32
 
 model:
   pretrained_model_name_or_path: "your-model-name"  # APIで使用するモデル名
-  bfcl_model_id:  # find id from "llm-leaderboard/scripts/evaluator/evaluate_utils/bfcl_pkg/SUPPORTED_MODELS.md"
+  bfcl_model_id: OpenRouter-FC # if it doesn't work, find id from "llm-leaderboard/scripts/evaluator/evaluate_utils/bfcl_pkg/SUPPORTED_MODELS.md"
   size_category: # "Small (<10B)", "Medium (10–30B)", "Large (30B+)"
   size: # parameter size
   release_date: # MM/DD/YYYY
+  base_model: # base model name such as "llama3.1", "qwen2.5"
 
 # Generator configuration
 generator:
+  max_tokens: 8192
   temperature: 0.01
   top_p: 1.0
-  max_tokens: 8192
+  parallel_tool_calls: true
+  tool_choice: auto
+  extra_body:
+    provider:
+      quantizations: ["bf16"]
+      allow_fallbacks: false

--- a/configs/config-example-vllm.yaml
+++ b/configs/config-example-vllm.yaml
@@ -4,28 +4,32 @@ wandb:
 api: "vllm-docker"  # 最もシンプルな指定（推奨）
 # base_urlは自動的に "http://vllm:8000/v1" が設定されます
 
+batch_size: 32
+
 model:
   use_wandb_artifacts: false
   pretrained_model_name_or_path: "" # huggingface model name
-  bfcl_model_id:  # find from "llm-leaderboard/scripts/evaluator/evaluate_utils/bfcl_pkg/SUPPORTED_MODELS.md"
+  bfcl_model_id:  # select "united_oss_fc" or "united_oss_jsonschema". If it doesn't work, find id from "llm-leaderboard/scripts/evaluator/evaluate_utils/bfcl_pkg/SUPPORTED_MODELS.md"
   size: # parameter size
   size_category:  # "Small (<10B)", "Medium (10–30B)", "Large (30B+)"
   base_model: "" # base model name such as "llama3.1", "qwen2.5"
   release_date:  # M/DD/YYYY
 
-batch_size: 32
 
 # vLLM server configuration
 vllm:
   vllm_tag: latest
   lifecycle: auto
-  # 以下はモデルにより調整が必要な場合のみ設定
+  # 以下はモデルにより調整が必要な場合のみ設定。
   # disable_triton_mma: false
   # dtype: bfloat16
   # max_model_len: 8192
   # device_map: auto
   # gpu_memory_utilization: 0.95
   # reasoning_parser: deepseek_r1
+  # ↓ Tool calling を有効にする場合は以下を設定。bfcl_model_idで"united_oss_fc"を利用する際は必要
+  # enable_auto_tool_choice: true
+  # tool_call_parser: hermes # variable can be found in https://docs.vllm.ai/en/v0.7.3/features/tool_calling.html#automatic-function-calling
   # trust_remote_code: false
 
 # Number of GPUs for tensor parallelism

--- a/configs/config-gpt-4.1-2025-04-14.yaml
+++ b/configs/config-gpt-4.1-2025-04-14.yaml
@@ -1,0 +1,14 @@
+wandb:
+  run_name: openai/gpt-4.1
+api: openai-compatible # openai, anthropic, google,..
+base_url: https://openrouter.ai/api/v1
+batch_size: 32
+model:
+  pretrained_model_name_or_path: openai/gpt-4.1-2025-04-14 #if you use openai api, put the name of model
+  bfcl_model_id: "OpenRouter-FC" # select among "OpenRouter-FC", "unified-oss-fc", "unified-oss-jsonschema" or if it doesn't work, find id from "llm-leaderboard/scripts/evaluator/evaluate_utils/bfcl_pkg/SUPPORTED_MODELS.md"
+  base_model: "unknown"
+  size_category: api
+  size: null
+  release_date: 4/14/2025
+
+

--- a/configs/config-meta-llama-Llama-3.2-3B-Instruct.yaml
+++ b/configs/config-meta-llama-Llama-3.2-3B-Instruct.yaml
@@ -1,0 +1,39 @@
+wandb:
+  run_name: meta-llama/Llama-3.2-3B-Instruct
+
+api: vllm-docker
+base_url: http://vllm:8000/v1
+batch_size: 32
+
+
+model:
+  use_wandb_artifacts: false
+  pretrained_model_name_or_path: meta-llama/Llama-3.2-3B-Instruct #if you use openai api, put the name of model
+  bfcl_model_id: unified-oss-jsonschema
+  size_category: Small (<10B)
+  size: 3210000000
+  release_date: 9/25/2024
+
+
+generator:
+  extra_body:
+    chat_template_kwargs:
+        enable_thinking: false
+  max_tokens: 40000 
+  temperature: 0.1
+  top_p: 1
+
+vllm:
+    disable_triton_mma: false
+    dtype: null
+    gpu_memory_utilization: 0.8
+    lifecycle: always_on
+    max_model_len: 40000
+    #reasoning_parser: 
+    enable_auto_tool_choice: true
+    tool_call_parser: llama3_json
+    trust_remote_code: true
+    vllm_tag: v0.8.5
+
+# Number of GPUs for tensor parallelism
+num_gpus: 1 

--- a/configs/config-meta-llama-Llama-3.3-70B-Instruct.yaml
+++ b/configs/config-meta-llama-Llama-3.3-70B-Instruct.yaml
@@ -1,0 +1,22 @@
+wandb:
+  run_name: "meta-llama/llama-3.3-70b-instruct"
+
+api: "openai-compatible"
+base_url: "https://openrouter.ai/api/v1"
+batch_size: 32
+
+model:
+  pretrained_model_name_or_path: "meta-llama/llama-3.3-70b-instruct"  # APIで使用するモデル名
+  bfcl_model_id: "OpenRouter-FC" # find id from "llm-leaderboard/scripts/evaluator/evaluate_utils/bfcl_pkg/SUPPORTED_MODELS.md"
+  size_category: "Large (30B+)"
+  size: 70553706496
+  release_date: "12/7/2024"
+
+# Generator configuration
+generator:
+  max_tokens: 8192
+  parallel_tool_calls: true
+  extra_body:
+    provider:
+      quantizations: ["bf16"]
+      allow_fallbacks: false  # フォールバック無効

--- a/configs/config-microsoft-phi-3-medium-128K-instruct.yaml
+++ b/configs/config-microsoft-phi-3-medium-128K-instruct.yaml
@@ -1,0 +1,36 @@
+wandb:
+  run_name: "microsoft/phi-3-medium-128k-instruct"
+api: vllm-docker
+base_url: http://vllm:8000/v1
+batch_size: 32
+model:
+  use_wandb_artifacts: false
+  pretrained_model_name_or_path: microsoft/phi-3-medium-128k-instruct #if you use openai api, put the name of model
+  bfcl_model_id: united_oss_fc
+  size_category: Small (<10B)
+  size: 3821079552
+  release_date: 6/27/2024
+
+generator:
+  extra_body:
+    chat_template_kwargs:
+        enable_thinking: false
+  max_tokens: 31232
+  temperature: 0.1
+  top_p: 1
+
+vllm:
+    device_map: null
+    disable_triton_mma: false
+    dtype: null
+    gpu_memory_utilization: 0.8
+    lifecycle: always_on
+    max_model_len: 31232
+    #reasoning_parser: 
+    enable_auto_tool_choice: true
+    tool_call_parser: phi4_mini_json
+    trust_remote_code: true
+    vllm_tag: v0.8.5
+
+# Number of GPUs for tensor parallelism
+num_gpus: 1 

--- a/scripts/evaluator/bfcl.py
+++ b/scripts/evaluator/bfcl.py
@@ -112,7 +112,7 @@ def evaluate():
 
     
     # Prediction 
-    generation_main(gen_args)
+    handler = generation_main(gen_args)
 
     # Evaluation
     # test_categoryを文字列からスペース区切りのリストに変換（評価用）
@@ -124,7 +124,8 @@ def evaluate():
         result_dir=bfcl_cfg['result_dir'],
         score_dir=bfcl_cfg['score_dir'],
         samples_per_category=bfcl_cfg['samples_per_category'],
-        artifacts_path=artifact_dir
+        artifacts_path=artifact_dir,
+        handler=handler
     )
     
     # Leaderboard Table

--- a/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/_llm_response_generation.py
+++ b/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/_llm_response_generation.py
@@ -320,7 +320,7 @@ def generate_results(args, model_name, test_cases_total):
                         result, result_dir=args.result_dir, update_mode=True
                     )  # Always use update_mode=True to prevent duplicate entries for the same test case
                     pbar.update()
-
+    return handler
 
 def main(args):
 
@@ -363,6 +363,6 @@ def main(args):
             f"All selected test cases have been previously generated for {args.model}. No new test cases to generate."
         )
     else:
-        generate_results(args, args.model_name, test_cases_total)
+        handler = generate_results(args, args.model_name, test_cases_total)
     
-    return test_cases_total
+    return handler

--- a/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/constants/model_config.py
+++ b/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/constants/model_config.py
@@ -122,6 +122,18 @@ class ModelConfig:
 
 # Inference through API calls
 api_inference_model_map = {
+    "OpenRouter-FC": ModelConfig(
+        model_name="OpenRouter-FC", # update later
+        display_name="OpenRouter (FC)", # filled as formality
+        url="https://openrouter.ai/", #filled as formality
+        org="OpenRouter",
+        license="Proprietary", # filled as formality
+        model_handler=OpenRouterHandler,
+        input_price=2, # filled as formality
+        output_price=8, # filled as formality
+        is_fc_model=True,
+        underscore_to_dot=True,
+    ),
     "gorilla-openfunctions-v2": ModelConfig(
         model_name="gorilla-openfunctions-v2",
         display_name="Gorilla-OpenFunctions-v2 (FC)",
@@ -1182,6 +1194,30 @@ api_inference_model_map = {
 
 # Inference through local hosting
 local_inference_model_map = {
+    "united_oss_fc": ModelConfig(
+        model_name="united_oss_fc",
+        display_name="united_oss_fc", # filled as formality
+        url="vllm", # filled as formality
+        org="vllm", # filled as formality
+        license="MIT", # filled as formality
+        model_handler=UnifiedOSSFCHandler,
+        input_price=None,
+        output_price=None,
+        is_fc_model=True,
+        underscore_to_dot=True,
+    ),
+    "united_oss_jsonschema": ModelConfig(
+        model_name="united_oss_jsonschema",
+        display_name="united_oss_jsonschema", # filled as formality
+        url="vllm", # filled as formality
+        org="vllm", # filled as formality
+        license="MIT", # filled as formality
+        model_handler=UnifiedOSSJsonSchemaHandler,
+        input_price=None,
+        output_price=None,
+        is_fc_model=False,
+        underscore_to_dot=True,
+    ),
     "deepseek-ai/DeepSeek-R1": ModelConfig(
         model_name="deepseek-ai/DeepSeek-R1",
         display_name="DeepSeek-R1 (Prompt) (Local)",

--- a/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/constants/model_config.py
+++ b/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/constants/model_config.py
@@ -1194,9 +1194,9 @@ api_inference_model_map = {
 
 # Inference through local hosting
 local_inference_model_map = {
-    "united_oss_fc": ModelConfig(
-        model_name="united_oss_fc",
-        display_name="united_oss_fc", # filled as formality
+    "unified-oss-fc": ModelConfig(
+        model_name="united-oss-fc",
+        display_name="united-oss-fc", # filled as formality
         url="vllm", # filled as formality
         org="vllm", # filled as formality
         license="MIT", # filled as formality
@@ -1206,9 +1206,9 @@ local_inference_model_map = {
         is_fc_model=True,
         underscore_to_dot=True,
     ),
-    "united_oss_jsonschema": ModelConfig(
-        model_name="united_oss_jsonschema",
-        display_name="united_oss_jsonschema", # filled as formality
+    "unified-oss-jsonschema": ModelConfig(
+        model_name="unified-oss-jsonschema",
+        display_name="unified-oss-jsonschema", # filled as formality
         url="vllm", # filled as formality
         org="vllm", # filled as formality
         license="MIT", # filled as formality

--- a/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/eval_checker/eval_runner.py
+++ b/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/eval_checker/eval_runner.py
@@ -415,7 +415,7 @@ def ast_file_runner(
 
 
 #### Main runner function ####
-def runner(model_names, test_categories, result_dir, score_dir, samples_per_category=None,artifacts_path=None):
+def runner(handler,model_names, test_categories, result_dir, score_dir, samples_per_category=None,artifacts_path=None):
 
     # State udpated by each eval subtask.
     state = dict(
@@ -438,9 +438,8 @@ def runner(model_names, test_categories, result_dir, score_dir, samples_per_cate
         if model_names is not None and model_name not in model_names:
             continue
 
-        model_name_escaped = model_name.replace("_", "/")
-
-        print(f"🦍 Model: {model_name}")
+        #model_name_escaped = model_name.replace("_", "/")
+        #print(f"🦍 Model: {model_name}")
 
         # Find and process all JSON files in the subdirectory
         for model_result_json in subdir.glob("*.json"):
@@ -448,7 +447,7 @@ def runner(model_names, test_categories, result_dir, score_dir, samples_per_cate
             if test_category not in test_categories:
                 continue
 
-            handler = get_handler(model_name_escaped)
+            #handler = get_handler(model_name_escaped)
 
             # We don't evaluate the following categories in the current iteration of the benchmark
             if is_chatable(test_category) or is_sql(test_category) or is_executable(test_category):
@@ -567,7 +566,7 @@ def evaluate_task(
     return state
 
 
-def main(model_names, test_categories, result_dir, score_dir, samples_per_category=None,artifacts_path=None):
+def main(handler, model_names, test_categories, result_dir, score_dir, samples_per_category=None,artifacts_path=None):
     if result_dir is None:
         result_dir = RESULT_PATH
     else:
@@ -593,7 +592,7 @@ def main(model_names, test_categories, result_dir, score_dir, samples_per_catego
     #        model_names.append(model_name.replace("/", "_"))
 
     # Driver function to run the evaluation for all categories involved.
-    non_live_df, live_df, multi_turn_df, overall_df = runner(model_names, all_test_categories, result_dir, score_dir, samples_per_category, artifacts_path)
+    non_live_df, live_df, multi_turn_df, overall_df = runner(handler, model_names, all_test_categories, result_dir, score_dir, samples_per_category, artifacts_path)
 
     print(
         f"🏁 Evaluation completed. See {score_dir / 'data_overall.csv'} for overall evaluation results on BFCL V3."

--- a/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/model_handler/api_inference/openrouter.py
+++ b/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/model_handler/api_inference/openrouter.py
@@ -5,4 +5,4 @@ class OpenRouterHandler(OpenAICompatibleHandler, EnforceOverrides):
     def __init__(self, model_name, temperature) -> None:
         # temperatureは後方互換のため残しているがgenerator_configから取るので使用しない
         super().__init__(model_name, temperature)
-        self.model_name = model_name.replace("-OpenRouter", "")
+        #self.model_name = model_name.replace("-OpenRouter", "")

--- a/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/model_handler/openai_compatible_handler.py
+++ b/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/model_handler/openai_compatible_handler.py
@@ -32,7 +32,7 @@ class OpenAICompatibleHandler(BaseHandler, EnforceOverrides):
         instance = WandbConfigSingleton.get_instance()
         cfg = instance.config
         self.model_name_huggingface = cfg.model.pretrained_model_name_or_path
-        self.generator_config = OmegaConf.to_container(cfg.bfcl.generator_config)
+        self.generator_config = OmegaConf.to_container(cfg.generator)
         self.max_tokens = self.generator_config.pop("max_tokens") # 使用済みTokenに応じて調整するためgenerator_configから取り除く
 
         # Read from env vars with fallbacks

--- a/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/model_handler/openai_compatible_handler.py
+++ b/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/model_handler/openai_compatible_handler.py
@@ -67,7 +67,7 @@ class OpenAICompatibleHandler(BaseHandler, EnforceOverrides):
         inference_data["inference_input_log"] = {"message": repr(message), "tools": tools}
 
         kwargs = {
-            "model": self.model_name_huggingface,
+            "model": self.model_name.replace("-FC", ""),
             "max_tokens": self.max_tokens,
             **self.generator_config,
         }
@@ -88,7 +88,7 @@ class OpenAICompatibleHandler(BaseHandler, EnforceOverrides):
         inference_data["inference_input_log"] = {"message": repr(message), "tools": tools}
 
         kwargs = {
-            "model": self.model_name_huggingface,
+            "model": self.model_name.replace("-FC", ""),
             "max_tokens": self.max_tokens,
             **self.generator_config,
         }

--- a/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/model_handler/openai_compatible_handler.py
+++ b/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/model_handler/openai_compatible_handler.py
@@ -67,7 +67,7 @@ class OpenAICompatibleHandler(BaseHandler, EnforceOverrides):
         inference_data["inference_input_log"] = {"message": repr(message), "tools": tools}
 
         kwargs = {
-            "model": self.model_name.replace("-FC", ""),
+            "model": self.model_name_huggingface,
             "max_tokens": self.max_tokens,
             **self.generator_config,
         }
@@ -88,7 +88,7 @@ class OpenAICompatibleHandler(BaseHandler, EnforceOverrides):
         inference_data["inference_input_log"] = {"message": repr(message), "tools": tools}
 
         kwargs = {
-            "model": self.model_name.replace("-FC", ""),
+            "model": self.model_name_huggingface,
             "max_tokens": self.max_tokens,
             **self.generator_config,
         }

--- a/scripts/llm_inference_adapter.py
+++ b/scripts/llm_inference_adapter.py
@@ -219,6 +219,879 @@ class ChatBedrock(BaseLLMClient):
 class OpenAIClient:
     def __init__(self, api_key=None, base_url=None, model=None, **kwargs):
         # タイムアウト設定を改善
+        timeout = httpx.Timeout(30.0, connect=10.0)
+        self.async_client = openai.AsyncOpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            timeout=timeout,
+            max_retries=3
+        )
+        self.client = openai.OpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            timeout=timeout,
+            max_retries=3
+        )
+        self.model = model
+        self.kwargs = kwargs
+        
+        self.allowed_params = {
+            'frequency_penalty', 'logit_bias', 'logprobs', 'max_tokens',
+            'n', 'presence_penalty', 'response_format', 'seed', 'stop',
+            'stream', 'temperature', 'top_p', 'tools', 'tool_choice',
+            'user', 'extra_body', 'functions', 'function_call'
+        }
+        
+        self.param_mapping = {}
+
+    def invoke(self, messages, max_tokens=None, **kwargs):
+        """同期版のinvoke（後方互換性のため）"""
+        all_kwargs = {**self.kwargs, **kwargs}
+        mapped_params = map_common_params(all_kwargs, self.param_mapping)
+        filtered_params = filter_params(mapped_params, self.allowed_params)
+        
+        params = {
+            "model": self.model,
+            "messages": messages,
+            **filtered_params
+        }
+        
+        if max_tokens:
+            params["max_tokens"] = max_tokens
+        
+        # extra_bodyを直接渡す（OpenRouterのprovider、reasoningなどに対応）
+        if "extra_body" in all_kwargs:
+            # DictConfigを通常の辞書に変換
+            try:
+                import omegaconf
+                if isinstance(all_kwargs["extra_body"], omegaconf.DictConfig):
+                    params["extra_body"] = omegaconf.OmegaConf.to_container(all_kwargs["extra_body"])
+                else:
+                    params["extra_body"] = all_kwargs["extra_body"]
+            except (ImportError, AttributeError):
+                # omegaconfが利用できない場合やDictConfigでない場合はそのまま使用
+                params["extra_body"] = all_kwargs["extra_body"]
+        
+        # 後方互換性のためのレガシーパラメータサポート
+        if "include_reasoning" in all_kwargs:
+            if "extra_body" not in params:
+                params["extra_body"] = {}
+            if all_kwargs["include_reasoning"] is True:
+                params["extra_body"]["reasoning"] = {}
+            elif all_kwargs["include_reasoning"] is False:
+                params["extra_body"]["reasoning"] = {"exclude": True}
+        
+        response = self.client.chat.completions.create(**params)
+        content = response.choices[0].message.content
+        # vLLM reasoning parser output
+        reasoning_content = getattr(response.choices[0].message, 'reasoning_content', '')
+        # OpenRouter reasoning field support
+        if not reasoning_content and hasattr(response.choices[0].message, 'reasoning'):
+            reasoning_content = getattr(response.choices[0].message, 'reasoning', '')
+        return LLMResponse(content=content, reasoning_content=reasoning_content)
+
+    async def ainvoke(self, messages, max_tokens=None, **kwargs):
+        """非同期版のinvoke"""
+        all_kwargs = {**self.kwargs, **kwargs}
+        mapped_params = map_common_params(all_kwargs, self.param_mapping)
+        filtered_params = filter_params(mapped_params, self.allowed_params)
+        
+        # OmegaConfオブジェクトを通常のPythonオブジェクトに変換
+        def convert_omegaconf(obj):
+            import omegaconf
+            if hasattr(obj, '_content') and hasattr(obj, '_metadata'):  # DictConfig
+                return omegaconf.OmegaConf.to_container(obj)
+            elif hasattr(obj, '_content') and not hasattr(obj, '_metadata'):  # ListConfig
+                return list(obj)
+            elif isinstance(obj, dict):
+                return {k: convert_omegaconf(v) for k, v in obj.items()}
+            elif isinstance(obj, list):
+                return [convert_omegaconf(item) for item in obj]
+            else:
+                return obj
+        
+        # すべてのパラメータを変換
+        filtered_params = convert_omegaconf(filtered_params)
+        
+        params = {
+            "model": self.model,
+            "messages": messages,
+            **filtered_params
+        }
+        
+        if max_tokens:
+            params["max_tokens"] = max_tokens
+        
+        # extra_bodyを直接渡す（OpenRouterのprovider、reasoningなどに対応）
+        if "extra_body" in all_kwargs:
+            # DictConfigを通常の辞書に変換
+            try:
+                import omegaconf
+                if isinstance(all_kwargs["extra_body"], omegaconf.DictConfig):
+                    params["extra_body"] = omegaconf.OmegaConf.to_container(all_kwargs["extra_body"])
+                elif isinstance(all_kwargs["extra_body"], omegaconf.ListConfig):
+                    params["extra_body"] = list(all_kwargs["extra_body"])
+                else:
+                    params["extra_body"] = all_kwargs["extra_body"]
+            except (ImportError, AttributeError):
+                # omegaconfが利用できない場合やDictConfigでない場合はそのまま使用
+                params["extra_body"] = all_kwargs["extra_body"]
+        
+        # 後方互換性のためのレガシーパラメータサポート
+        if "include_reasoning" in all_kwargs:
+            if "extra_body" not in params:
+                params["extra_body"] = {}
+            if all_kwargs["include_reasoning"] is True:
+                params["extra_body"]["reasoning"] = {}
+            elif all_kwargs["include_reasoning"] is False:
+                params["extra_body"]["reasoning"] = {"exclude": True}
+
+        # Structured output
+        if "response_format" in params:
+            response: OpenAIChatCompletion = await self.async_client.beta.chat.completions.parse(**params)
+            parsed_output = response.choices[0].message.parsed
+        else:
+            response: OpenAIChatCompletion = await self.async_client.chat.completions.create(**params)
+            parsed_output = None
+
+        content = response.choices[0].message.content
+        # vLLM reasoning parser output
+        # https://docs.vllm.ai/en/latest/features/reasoning_outputs.html#quickstart
+        reasoning_content = getattr(response.choices[0].message, 'reasoning_content', '')
+        # OpenRouter reasoning field support
+        if not reasoning_content and hasattr(response.choices[0].message, 'reasoning'):
+            reasoning_content = getattr(response.choices[0].message, 'reasoning', '')
+
+        llm_response = LLMResponse(
+            content=content,
+            reasoning_content=reasoning_content,
+            parsed_output=parsed_output,
+            prompt_tokens=response.usage.prompt_tokens,
+            completion_tokens=response.usage.completion_tokens
+        )
+
+        def parse_arguments(arguments: str):
+            """
+            ArgumentsのJSONをパースする
+            OpenRouterなどの一部の互換実装ではValid JSONではなく空文字や最後の}がないケースがあるのでカバーする
+            """
+            if arguments is None or arguments == "":
+                return {}
+            try:
+                return json.loads(arguments)
+            except json.JSONDecodeError as e1:
+                try:
+                    return json.loads(arguments + '}')
+                except json.JSONDecodeError:
+                    raise e1
+
+        if tool_calls := response.choices[0].message.tool_calls:
+            llm_response.tool_calls = [ToolCall(
+                name=tool_call.function.name,
+                arguments=parse_arguments(tool_call.function.arguments),
+                id=tool_call.id,
+                type=tool_call.type
+            ) for tool_call in tool_calls]
+
+        return llm_response
+
+
+class OpenAIResponsesClient(BaseLLMClient):
+    """
+    OpenAIのResponses APIを使用するクライアント(Reasoning対応)
+    """
+    def __init__(self, api_key=None, base_url=None, model=None, structured=False, **kwargs):
+        self.async_client = openai.AsyncOpenAI(
+            api_key=api_key,
+            base_url=base_url
+        )
+        self.model = model
+        self.kwargs = kwargs
+        self.structured = structured
+        
+        self.allowed_params = {
+            'instructions', 'max_output_tokens', 'max_tool_calls', 'metadata',
+            'parallel_tool_calls', 'previous_response_id', 'reasoning', 
+            'service_tier', 'store', 'stream', 'temperature', 'text', 'text_format',
+            'tool_choice', 'tools', 'top_logprobs', 'top_p', 'truncation', 'user',
+        }
+
+        self.param_mapping = {'max_tokens': 'max_output_tokens', 'top_k': 'top_logprobs'}
+
+    async def ainvoke(self, messages, max_tokens=None, **kwargs):
+        """非同期版のinvoke"""
+        all_kwargs = {**self.kwargs, **kwargs}
+        mapped_params = map_common_params(all_kwargs, self.param_mapping)
+        filtered_params = filter_params(mapped_params, self.allowed_params)
+        
+        params = {
+            "model": self.model,
+            "input": messages,
+            **filtered_params
+        }
+        
+        if max_tokens:
+            params["max_output_tokens"] = max_tokens
+        
+        if 'text_format' in filtered_params:
+            response: OpenAIParsedResponse = await self.async_client.responses.parse(**params)
+            parsed_output = response.output_parsed
+        else:
+            response: OpenAIResponse = await self.async_client.responses.create(**params)
+            parsed_output = None
+
+        content, reasoning_content = "", ""
+        for output in response.output:
+            if output.type == "message":
+                content = output.content[0].text
+            elif output.type == "reasoning" and len(output.summary) > 0: # reasoning contentは長さ0の場合がある
+                reasoning_content = output.summary[0].text
+        return LLMResponse(content=content, reasoning_content=reasoning_content, parsed_output=parsed_output)
+
+
+class AzureOpenAIResponsesClient(OpenAIResponsesClient):
+    def __init__(self, api_key, azure_endpoint, azure_deployment, api_version, structured=False, **kwargs):
+        self.async_client = openai.AsyncAzureOpenAI(
+            api_key=api_key,
+            azure_endpoint=azure_endpoint,
+            api_version=api_version
+        )
+        self.model = azure_deployment
+        self.kwargs = kwargs
+        self.structured = structured
+
+        self.allowed_params = {
+            'temperature', 'top_p', 'n', 'stream', 'stop', 
+            'max_tokens', 'presence_penalty', 'frequency_penalty',
+            'logit_bias', 'user', 'response_format', 'seed',
+            'tools', 'tool_choice', 'parallel_tool_calls', 'extra_body',
+        }
+        
+        self.param_mapping = {}
+
+
+# ================================ Client factory function ===========================
+
+
+class AzureOpenAIResponsesClient(OpenAIResponsesClient):
+    def __init__(self, api_key, azure_endpoint, azure_deployment, api_version, structured=False, **kwargs):
+        self.async_client = openai.AsyncAzureOpenAI(
+            api_key=api_key,
+            azure_endpoint=azure_endpoint,
+            api_version=api_version
+        )
+        self.model = azure_deployment
+        self.kwargs = kwargs
+        self.structured = structured
+
+        self.allowed_params = {
+            'instructions', 'max_output_tokens', 'max_tool_calls', 'metadata',
+            'parallel_tool_calls', 'previous_response_id', 'reasoning', 
+            'service_tier', 'store', 'stream', 'temperature', 'text',
+            'tool_choice', 'tools', 'top_logprobs', 'top_p', 'truncation', 'user',
+        }
+
+        self.param_mapping = {'max_tokens': 'max_output_tokens', 'top_k': 'top_logprobs'}
+
+
+class MistralClient(BaseLLMClient):
+    def __init__(self, api_key, model, **kwargs):
+        self.client = Mistral(api_key=api_key)
+        self.model = model
+        self.kwargs = kwargs
+        
+        self.allowed_params = {
+            'temperature', 'top_p', 'max_tokens', 'stream', 'stop',
+            'random_seed', 'response_format', 'tools', 'tool_choice'
+        }
+        
+        self.param_mapping = {
+            'seed': 'random_seed',
+        }
+
+    async def ainvoke(self, messages, max_tokens=None, **kwargs):
+        """非同期版のinvoke"""
+        all_kwargs = {**self.kwargs, **kwargs}
+        mapped_params = map_common_params(all_kwargs, self.param_mapping)
+        filtered_params = filter_params(mapped_params, self.allowed_params)
+        
+        params = {
+            "model": self.model,
+            "messages": messages,
+            **filtered_params
+        }
+        
+        if max_tokens:
+            params["max_tokens"] = max_tokens
+        
+        # Mistral APIを非同期で実行
+        response = await asyncio.to_thread(self.client.chat.complete, **params)
+        return LLMResponse(content=response.choices[0].message.content)
+
+
+class GoogleClient(BaseLLMClient):
+    def __init__(self, api_key, model, **kwargs):
+        genai.configure(api_key=api_key)
+        self.model = genai.GenerativeModel(model)
+        self.kwargs = kwargs
+        
+        self.allowed_params = {
+            'temperature', 'top_p', 'top_k', 'max_output_tokens',
+            'candidate_count', 'stop_sequences'
+        }
+        
+        self.param_mapping = {
+            'max_tokens': 'max_output_tokens',
+            'stop': 'stop_sequences',
+        }
+
+    async def ainvoke(self, messages, max_tokens=None, **kwargs):
+        """非同期版のinvoke"""
+        # メッセージ処理
+        chat_history = []
+        system_instruction = None
+        
+        for i, msg in enumerate(messages):
+            if msg["role"] == "system":
+                system_instruction = msg["content"]
+            elif msg["role"] == "user":
+                if i < len(messages) - 1:
+                    chat_history.append({"role": "user", "parts": [msg["content"]]})
+            elif msg["role"] == "assistant":
+                chat_history.append({"role": "model", "parts": [msg["content"]]})
+        
+        if system_instruction:
+            model = genai.GenerativeModel(
+                model_name=self.model.model_name,
+                system_instruction=system_instruction
+            )
+        else:
+            model = self.model
+        
+        chat = model.start_chat(history=chat_history)
+        
+        last_user_message = None
+        for msg in reversed(messages):
+            if msg["role"] == "user":
+                last_user_message = msg["content"]
+                break
+        
+        if not last_user_message:
+            raise ValueError("No user message found")
+        
+        all_kwargs = {**self.kwargs, **kwargs}
+        mapped_params = map_common_params(all_kwargs, self.param_mapping)
+        generation_config = filter_params(mapped_params, self.allowed_params)
+        
+        if max_tokens:
+            generation_config["max_output_tokens"] = max_tokens
+        
+        # Google APIを非同期で実行
+        for i in range(10):
+            response = await asyncio.to_thread(
+                chat.send_message,
+                last_user_message,
+                generation_config=generation_config
+            )
+            # Googleの場合は空のレスポンスに対してリトライ処理
+            if response.text.strip():
+                break
+            print(f"Retrying request due to empty content. Retry attempt {i+1} of 10.")
+        return LLMResponse(content=response.text)
+
+
+class AnthropicClient(BaseLLMClient):
+    def __init__(self, api_key, model, **kwargs):
+        self.client = Anthropic(api_key=api_key)
+        self.model = model
+        self.kwargs = kwargs
+        
+        self.allowed_params = {
+            'temperature', 'top_p', 'top_k', 'max_tokens',
+            'stop_sequences', 'stream'
+        }
+        
+        self.param_mapping = {
+            'stop': 'stop_sequences',
+        }
+
+    async def ainvoke(self, messages, max_tokens=None, **kwargs):
+        """非同期版のinvoke"""
+        system_message = None
+        filtered_messages = []
+        
+        for msg in messages:
+            if msg["role"] == "system":
+                system_message = msg["content"]
+            else:
+                filtered_messages.append(msg)
+        
+        all_kwargs = {**self.kwargs, **kwargs}
+        mapped_params = map_common_params(all_kwargs, self.param_mapping)
+        filtered_params = filter_params(mapped_params, self.allowed_params)
+        
+        params = {
+            "model": self.model,
+            "messages": filtered_messages,
+            **filtered_params
+        }
+        
+        if system_message:
+            params["system"] = system_message
+        
+        # Anthropic純正API用のthinking対応
+        params, reasoning_content = self._configure_thinking(params, max_tokens, all_kwargs)
+        
+        # Anthropic APIを非同期で実行
+        try:
+            response = await asyncio.to_thread(self.client.messages.create, **params)
+        except Exception as e:
+            # AnthropicエラーをOpenAI互換エラーに変換してLLMAsyncProcessorのbackoffに対応
+            import openai
+            import anthropic
+            
+            if isinstance(e, anthropic.APITimeoutError):
+                raise openai.APITimeoutError(f"Anthropic API timeout: {str(e)}")
+            elif isinstance(e, anthropic.RateLimitError):
+                raise openai.RateLimitError(f"Anthropic rate limit: {str(e)}")
+            elif isinstance(e, anthropic.InternalServerError):
+                raise openai.InternalServerError(f"Anthropic internal server error: {str(e)}")
+            elif isinstance(e, anthropic.APIConnectionError):
+                raise openai.APIConnectionError(f"Anthropic connection error: {str(e)}")
+            elif "timeout" in str(e).lower() or "timed out" in str(e).lower():
+                raise openai.APITimeoutError(f"Anthropic API timeout: {str(e)}")
+            elif "rate limit" in str(e).lower():
+                raise openai.RateLimitError(f"Anthropic rate limit: {str(e)}")
+            else:
+                # その他のエラーはそのまま再発生
+                raise
+        
+        # レスポンス処理（thinking対応）
+        content = ""
+        thinking_content = ""
+        
+        for block in response.content:
+            if hasattr(block, 'type'):
+                if block.type == "text":
+                    content = block.text
+                elif block.type == "thinking":
+                    thinking_content = getattr(block, 'thinking', '')
+        
+        return LLMResponse(content=content, reasoning_content=thinking_content)
+    
+    def _configure_thinking(self, params, max_tokens, all_kwargs):
+        """Anthropic純正API用のthinking設定"""
+        try:
+            # Docker環境での正しいインポートパス
+            instance = WandbConfigSingleton.get_instance()
+            cfg = instance.config
+            
+            # thinking設定を取得
+            thinking_config = getattr(cfg.model, 'thinking', None)
+            
+            if thinking_config:
+                budget_tokens = thinking_config.get('budget_tokens', 16384)
+                
+                # max_tokensを設定（回答用 + 推論用）
+                answer_tokens = max_tokens or 2048
+                total_max_tokens = answer_tokens + budget_tokens
+                
+                params["max_tokens"] = total_max_tokens
+                params["thinking"] = {
+                    "type": "enabled",
+                    "budget_tokens": budget_tokens
+                }
+                
+                # Anthropic thinking有効時はtemperatureを1に設定する必要がある
+                params["temperature"] = 1.0
+                
+                print(f"Anthropic thinking configuration: total={total_max_tokens} "
+                      f"(answer={answer_tokens}, budget={budget_tokens}), temperature=1.0")
+                
+                return params, True
+            else:
+                # thinking設定がない場合は通常の処理
+                if max_tokens:
+                    params["max_tokens"] = max_tokens
+                elif "max_tokens" not in params:
+                    params["max_tokens"] = 1024
+                
+                return params, False
+                
+        except Exception as e:
+            print(f"Failed to configure Anthropic thinking: {e}")
+            # エラーの場合は通常の処理にフォールバック
+            if max_tokens:
+                params["max_tokens"] = max_tokens
+            elif "max_tokens" not in params:
+                params["max_tokens"] = 1024
+            
+            return params, False
+
+
+class AzureOpenAIClient(BaseLLMClient):
+    def __init__(self, api_key, azure_endpoint, azure_deployment, api_version, **kwargs):
+        self.client = AzureOpenAI(
+            api_key=api_key,
+            azure_endpoint=azure_endpoint,
+            api_version=api_version
+        )
+        self.async_client = openai.AsyncAzureOpenAI(
+            api_key=api_key,
+            azure_endpoint=azure_endpoint,
+            api_version=api_version
+        )
+        self.azure_deployment = azure_deployment
+        self.kwargs = kwargs
+        
+        self.allowed_params = {
+            'temperature', 'top_p', 'n', 'stream', 'stop', 
+            'max_tokens', 'presence_penalty', 'frequency_penalty',
+            'logit_bias', 'user', 'response_format', 'seed',
+            'tools', 'tool_choice', 'parallel_tool_calls'
+        }
+        
+        self.param_mapping = {}
+
+    async def ainvoke(self, messages, max_tokens=None, **kwargs):
+        """非同期版のinvoke"""
+        all_kwargs = {**self.kwargs, **kwargs}
+        mapped_params = map_common_params(all_kwargs, self.param_mapping)
+        filtered_params = filter_params(mapped_params, self.allowed_params)
+        
+        params = {
+            "model": self.azure_deployment,
+            "messages": messages,
+            **filtered_params
+        }
+        
+        if max_tokens:
+            params["max_tokens"] = max_tokens
+        
+        response = await self.async_client.chat.completions.create(**params)
+        return LLMResponse(content=response.choices[0].message.content)
+
+
+class CohereClient(BaseLLMClient):
+    def __init__(self, api_key, model, **kwargs):
+        # タイムアウト設定
+        import httpx
+        timeout_config = httpx.Timeout(
+            connect=30.0,   # 接続タイムアウト30秒
+            read=300.0,     # 読み取りタイムアウト5分
+            write=300.0,    # 書き込みタイムアウト5分
+            pool=30.0       # プールタイムアウト30秒
+        )
+        
+        # モデル名に基づいてクライアントバージョンを選択
+        # command-a-* や新しいモデルはv2を使用
+        self.use_v2 = "command-a" in model.lower() or "2025" in model
+        
+        try:
+            if self.use_v2:
+                print(f"Using Cohere v2 client for model: {model}")
+                self.client = cohere.ClientV2(
+                    api_key=api_key,
+                    timeout=timeout_config,
+                    max_retries=3
+                )
+            else:
+                print(f"Using Cohere v1 client for model: {model}")
+                self.client = cohere.Client(
+                    api_key=api_key,
+                    timeout=timeout_config,
+                    max_retries=3
+                )
+        except Exception as e:
+            print(f"Failed to initialize Cohere client: {e}")
+            raise
+            
+        self.model = model
+        self.kwargs = kwargs
+        
+        self.allowed_params = {
+            'temperature', 'p', 'k', 'max_tokens', 'stop_sequences',
+            'frequency_penalty', 'presence_penalty', 'seed'
+        }
+        
+        self.param_mapping = {
+            'top_p': 'p',
+            'top_k': 'k',
+            'stop': 'stop_sequences',
+        }
+
+    async def ainvoke(self, messages, max_tokens=None, **kwargs):
+        """非同期版のinvoke - v1/v2両対応"""
+        if self.use_v2:
+            return await self._ainvoke_v2(messages, max_tokens, **kwargs)
+        else:
+            return await self._ainvoke_v1(messages, max_tokens, **kwargs)
+    
+    async def _ainvoke_v2(self, messages, max_tokens=None, **kwargs):
+        """v2 API用の非同期実装"""
+        # v2 API用のメッセージ形式に変換
+        v2_messages = []
+        system_message = None
+        
+        for msg in messages:
+            if msg["role"] == "system":
+                system_message = msg["content"]
+            elif msg["role"] == "user":
+                v2_messages.append({"role": "user", "content": msg["content"]})
+            elif msg["role"] == "assistant":
+                v2_messages.append({"role": "assistant", "content": msg["content"]})
+        
+        all_kwargs = {**self.kwargs, **kwargs}
+        mapped_params = map_common_params(all_kwargs, self.param_mapping)
+        filtered_params = filter_params(mapped_params, self.allowed_params)
+        
+        params = {
+            "model": self.model,
+            "messages": v2_messages,
+            **filtered_params
+        }
+        
+        if system_message:
+            params["system"] = system_message
+            
+        if max_tokens:
+            params["max_tokens"] = max_tokens
+        
+        try:
+            # Cohere v2 APIを非同期で実行
+            response = await asyncio.to_thread(self.client.chat, **params)
+            # v2 APIのレスポンス形式に対応
+            content = response.message.content[0].text if response.message.content else ""
+            return LLMResponse(content=content)
+        except Exception as e:
+            print(f"Cohere v2 API error: {type(e).__name__}: {e}")
+            if "timeout" in str(e).lower():
+                print("Connection timeout - check network connectivity and API status")
+            raise
+    
+    async def _ainvoke_v1(self, messages, max_tokens=None, **kwargs):
+        """v1 API用の非同期実装（既存のコード）"""
+import os
+import asyncio
+from dataclasses import dataclass, field
+from abc import ABC, abstractmethod
+from typing import List, Dict, Optional, Union, Any
+import uuid
+import json
+import warnings
+import logging
+from config_singleton import WandbConfigSingleton
+from omegaconf import OmegaConf, DictConfig
+import openai
+from openai.types.responses import Response as OpenAIResponse, ParsedResponse as OpenAIParsedResponse
+from openai.types.chat import ChatCompletion as OpenAIChatCompletion
+from mistralai import Mistral
+import google.generativeai as genai
+from anthropic import Anthropic
+import cohere
+from botocore.exceptions import ClientError
+import boto3
+from botocore.config import Config
+from openai import AzureOpenAI
+import httpx
+from pydantic import BaseModel
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ToolCall:
+    name: str
+    arguments: Dict[str, Any]
+    type: str = 'function'
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+
+
+@dataclass
+class LLMResponse:
+    content: str
+    reasoning_content: str = ""
+    parsed_output: Optional[BaseModel] = None
+    tool_calls: Optional[List[ToolCall]] = None
+    prompt_tokens: Optional[int] = None
+    completion_tokens: Optional[int] = None
+
+
+def filter_params(params, allowed_params):
+    """許可されたパラメータのみをフィルタリング"""
+    return {k: v for k, v in params.items() if k in allowed_params}
+
+
+def map_common_params(params, param_mapping):
+    """共通パラメータを各プロバイダ固有のパラメータ名にマッピング"""
+    mapped_params = {}
+    for key, value in params.items():
+        mapped_key = param_mapping.get(key, key)
+        if isinstance(value, DictConfig):
+            value = OmegaConf.to_container(value)
+        mapped_params[mapped_key] = value
+    return mapped_params
+
+
+class BaseLLMClient(ABC):
+    def invoke(self, messages: List[Dict[str, str]], max_tokens: Optional[int] = None, **kwargs) -> LLMResponse:
+        """同期版のinvoke（後方互換性のため）"""
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            return loop.run_until_complete(self.ainvoke(messages, max_tokens, **kwargs))
+        finally:
+            loop.close()
+
+    @abstractmethod
+    async def ainvoke(self, messages: List[Dict[str, str]], max_tokens: Optional[int] = None, **kwargs) -> LLMResponse:
+        raise NotImplementedError
+
+
+class ChatBedrock(BaseLLMClient):
+    def __init__(self, cfg) -> None:
+        # 接続プールとタイムアウト設定を改善
+        config = Config(
+            read_timeout=1000,
+            connect_timeout=60,
+            max_pool_connections=50,  # 接続プールサイズを増加
+        )
+        
+        self.bedrock_runtime = boto3.client(
+            service_name="bedrock-runtime",
+            region_name=os.environ.get("AWS_DEFAULT_REGION", "us-west-1"),
+            config=config,
+        )
+        self.model_id = cfg.model.pretrained_model_name_or_path
+        self.ignore_keys = ["max_tokens"]
+        self.generator_config = {
+            k: v for k, v in cfg.generator.items() if k not in self.ignore_keys
+        }
+
+    async def _invoke_async(self, messages: list[dict[str, str]], max_tokens: int):
+        """非同期でBedrockを呼び出し"""
+        is_claude = "anthropic" in self.model_id.lower()
+        is_llama = "llama" in self.model_id.lower()
+        is_nova = "nova" in self.model_id.lower()
+
+        if is_claude:
+            body_dict = {
+                "anthropic_version": "bedrock-2023-05-31",
+                "max_tokens": max_tokens,
+                **self.generator_config,
+            }
+            if messages[0]["role"] == "system":
+                body_dict.update({"messages": messages[1:], "system": messages[0]["content"]})
+            else:
+                body_dict.update({"messages": messages})
+        elif is_llama:
+            prompt = self._format_llama_prompt(messages)
+            body_dict = {
+                "prompt": prompt,
+                "max_gen_len": max_tokens,
+                **self.generator_config,
+            }
+        elif is_nova:
+            for message in messages:
+                if isinstance(message['content'], str):
+                    message['content'] = [{"text": message['content']}]
+
+            parameter_mapping = {
+                "top_p": "topP",
+                "max_tokens": "maxTokens",
+            }
+
+            inference_config = {
+                parameter_mapping.get(k, k): v for k, v in {
+                    "temperature": self.generator_config.get("temperature", 0.0),
+                    "maxTokens": max_tokens,
+                    **{k: v for k, v in self.generator_config.items() if k not in ["temperature"]}
+                }.items()
+            }
+
+            body_dict = {
+                "messages": messages,
+                "inferenceConfig": inference_config
+            }
+        else:
+            raise ValueError(f"Unsupported model: {self.model_id}")
+
+        try:
+            if is_nova:
+                # 非同期でconverseを実行
+                response = await asyncio.to_thread(
+                    self.bedrock_runtime.converse,
+                    modelId=self.model_id,
+                    **body_dict
+                )
+                response_body = response
+            else:
+                # 非同期でinvoke_modelを実行
+                response = await asyncio.to_thread(
+                    self.bedrock_runtime.invoke_model,
+                    body=json.dumps(body_dict),
+                    modelId=self.model_id
+                )
+                response_body = json.loads(response.get("body").read())
+        except ClientError as e:
+            print(f"ERROR: Can't invoke '{self.model_id}'. Reason: {e}")
+            raise
+        except Exception as e:
+            print(f"ERROR: Unexpected error during invocation of '{self.model_id}'. Reason: {e}")
+            # エラーの場合は空のレスポンスを返す
+            return {"content": []}
+
+        return response_body
+
+    def _format_llama_prompt(self, messages):
+        formatted_messages = ["<|begin_of_text|>"]
+        for message in messages:
+            if message["role"] == "system":
+                formatted_messages.append(f"<|start_header_id|>system<|end_header_id|>\n{message['content']}\n<|eot_id|>")
+            elif message["role"] == "user":
+                formatted_messages.append(f"<|start_header_id|>user<|end_header_id|>\n{message['content']}\n<|eot_id|>")
+            elif message["role"] == "assistant":
+                formatted_messages.append(f"<|start_header_id|>assistant<|end_header_id|>\n{message['content']}\n<|eot_id|>")
+        return "".join(formatted_messages)
+
+    def invoke(self, messages, max_tokens=None, **kwargs):
+        """同期版のinvoke（後方互換性のため）"""
+        if max_tokens is None:
+            max_tokens = 1024
+        return super().invoke(messages, max_tokens, **kwargs)
+
+    async def ainvoke(self, messages, max_tokens=None, **kwargs):
+        """非同期版のinvoke"""
+        if max_tokens is None:
+            max_tokens = 1024
+        
+        response = await self._invoke_async(messages=messages, max_tokens=max_tokens)
+        
+        if "anthropic" in self.model_id.lower():
+            content_list = response.get("content", [])
+            if content_list and len(content_list) > 0:
+                content = content_list[0].get("text", "")
+            else:
+                content = ""
+        elif "llama" in self.model_id.lower():
+            content = response.get("generation", "")
+            content = content.replace("<|start_header_id|>assistant<|end_header_id|>\n", "").replace("\n<|eot_id|>", "") 
+        elif "nova" in self.model_id.lower():
+            content_list = response.get("output", {}).get("message", {}).get("content", [])
+            if content_list and len(content_list) > 0:
+                content = content_list[0].get("text", "")
+            else:
+                content = ""
+        else:
+            content = ""
+        
+        return LLMResponse(content=content)
+
+
+class OpenAIClient:
+    def __init__(self, api_key=None, base_url=None, model=None, **kwargs):
+        # タイムアウト設定を改善
         timeout_config = httpx.Timeout(
             connect=30.0,  # 接続タイムアウトを30秒に設定
             read=300.0,    # 読み取りタイムアウトを5分に設定
@@ -302,6 +1175,23 @@ class OpenAIClient:
         mapped_params = map_common_params(all_kwargs, self.param_mapping)
         filtered_params = filter_params(mapped_params, self.allowed_params)
         
+        # OmegaConfオブジェクトを通常のPythonオブジェクトに変換
+        def convert_omegaconf(obj):
+            import omegaconf
+            if hasattr(obj, '_content') and hasattr(obj, '_metadata'):  # DictConfig
+                return omegaconf.OmegaConf.to_container(obj)
+            elif hasattr(obj, '_content') and not hasattr(obj, '_metadata'):  # ListConfig
+                return list(obj)
+            elif isinstance(obj, dict):
+                return {k: convert_omegaconf(v) for k, v in obj.items()}
+            elif isinstance(obj, list):
+                return [convert_omegaconf(item) for item in obj]
+            else:
+                return obj
+        
+        # すべてのパラメータを変換
+        filtered_params = convert_omegaconf(filtered_params)
+        
         params = {
             "model": self.model,
             "messages": messages,
@@ -318,6 +1208,8 @@ class OpenAIClient:
                 import omegaconf
                 if isinstance(all_kwargs["extra_body"], omegaconf.DictConfig):
                     params["extra_body"] = omegaconf.OmegaConf.to_container(all_kwargs["extra_body"])
+                elif isinstance(all_kwargs["extra_body"], omegaconf.ListConfig):
+                    params["extra_body"] = list(all_kwargs["extra_body"])
                 else:
                     params["extra_body"] = all_kwargs["extra_body"]
             except (ImportError, AttributeError):


### PR DESCRIPTION
BFCLに関するPR

Summary:  bfclのIDに, OpenRouter-FC, unified-oss-fc, unified-oss-jsonschemaを追加し、簡単に選択できるようにupdate
気になるところはあるが、動くようになったので、チームにSyncするためにPRしています

- OpenRouter-FCのAPI 
    - GPT-4-1では問題なし   [Test Run ID](https://wandb.ai/llm-leaderboard/nejumi-leaderboard4-dev-bfcl/runs/i8hwc6fz) 
    - microsoft-phi-3-medium-128K-instruct
        - response fieldがAzure OpenAIが裏側にあると受け付けられないという問題まで特定。つまり、tool use のinterfaceが同じであっても functionの渡し方などはproviderごとに調整する必要があると判明 :rotating_light: -> こうした場合には、OpenRouterや元のclassを利用する
    - meta-llama/llama-3.3-70b-instruct [Test Run ID](https://wandb.ai/llm-leaderboard/nejumi-leaderboard4-dev-bfcl/runs/mjip115j)
        - parallel-tool-calls　をtrueに設定。いくつかの問題では複数のtoolが返ってきている一方、スコアが0.  ["Invalid syntax. Failed to decode AST. 'str' object has no attribute 'keys'"]というエラーがある。調査する
- unified-oss-fc, unified-oss-jsonschema
    - [Test Run IDs]( https://wandb.ai/llm-leaderboard/nejumi-leaderboard4-dev-bfcl/workspace?nw=dc1hb00dwzu)
    - テスト設定：unified-oss-fcとunified-oss-jsonschemaとそれぞれ日本語と英語でテスト
    - 結果：
        - ほとんどスコアは変わらない
        - LLama-3.2-3B-instructは、single tool use しか使えないという新しい仕様に遭遇. ただ、もうこれはモデルの限界と捉える?
        - LLama-3.2-3B-instructのBFCL公式スコアは0.45 である一方、上記方式だと英語の問題でも0.2ほど。調査必要



This pull request introduces several improvements and new configuration files to streamline model evaluation and configuration management for both API and local inference workflows. The main changes include unified model naming and handler logic, expanded support for new models, and enhanced configuration options for generator and tool-calling features.

**Configuration improvements and new model support:**

* Added new configuration files for `gpt-4.1-2025-04-14`, `meta-llama/Llama-3.2-3B-Instruct`, `meta-llama/llama-3.3-70b-instruct`, and `microsoft/phi-3-medium-128k-instruct`, enabling easy benchmarking and evaluation of these models. [[1]](diffhunk://#diff-33f1a6130e22d89f3e693fb6851184f80175ac6646968d09c5048e282005ea2dR1-R14) [[2]](diffhunk://#diff-c99be4b4592d809b0f1396f5d365b4d484e8625d0732bfb3d28dc80594e8f2cdR1-R39) [[3]](diffhunk://#diff-a961236bd799c72b5bc2c8516f2c179879ffa13d57dd25e1f2ea6e565df7bfc4R1-R22) [[4]](diffhunk://#diff-e20119d7f041d54255e47109a1e1af6f6348c0f1bb0522fc7aa34e686baee004R1-R36)
* Updated example configuration files (`config-example-openai-compatible.yaml`, `config-example-vllm.yaml`) to clarify model selection, add generator options (such as `max_tokens`, tool-calling, and quantization), and improve documentation for model IDs. [[1]](diffhunk://#diff-f32e0ab7c4dc03461601993b16a94dec34efdc2d88f14232f5ba1d9559f32ebeL5-R26) [[2]](diffhunk://#diff-4552b1c07c1746be0ad40a681493be10d650a81913c99a9f1fc6fa2a66f5e56eR7-R32)

**Model handler and naming unification:**

* Refactored local inference handlers to consistently use the model name from the configuration (`pretrained_model_name_or_path`) instead of relying on string replacements, ensuring correct model identification and reducing errors. [[1]](diffhunk://#diff-2f90f5226523258379ef411fddf912ccdd38873ba30cd6949ff5d8b9d4b56efaL8-R18) [[2]](diffhunk://#diff-2f90f5226523258379ef411fddf912ccdd38873ba30cd6949ff5d8b9d4b56efaL37-R48) [[3]](diffhunk://#diff-2f90f5226523258379ef411fddf912ccdd38873ba30cd6949ff5d8b9d4b56efaL95-R99) [[4]](diffhunk://#diff-2f90f5226523258379ef411fddf912ccdd38873ba30cd6949ff5d8b9d4b56efaL118-R122) [[5]](diffhunk://#diff-2f90f5226523258379ef411fddf912ccdd38873ba30cd6949ff5d8b9d4b56efaL158-R162) [[6]](diffhunk://#diff-2f90f5226523258379ef411fddf912ccdd38873ba30cd6949ff5d8b9d4b56efaL193-R197)
* Updated handler logic in evaluation scripts to pass handler objects directly through the pipeline, simplifying handler management and improving code clarity. [[1]](diffhunk://#diff-9c6a76efaa625af1025e31aecb3bf4ad6458b2e1e3807302d55bcc51b6a03873L115-R115) [[2]](diffhunk://#diff-9c6a76efaa625af1025e31aecb3bf4ad6458b2e1e3807302d55bcc51b6a03873L127-R128) [[3]](diffhunk://#diff-2a895b2562191a2dcc60f4ea86c0613654ff0b1063c02127b9b36412092b237aL323-R323) [[4]](diffhunk://#diff-2a895b2562191a2dcc60f4ea86c0613654ff0b1063c02127b9b36412092b237aL366-R368) [[5]](diffhunk://#diff-c0297ddf498b772ae8691ed5a45f3e398e33252716645fa2d9d1e59c095aefeaL418-R418) [[6]](diffhunk://#diff-c0297ddf498b772ae8691ed5a45f3e398e33252716645fa2d9d1e59c095aefeaL441-R450) [[7]](diffhunk://#diff-c0297ddf498b772ae8691ed5a45f3e398e33252716645fa2d9d1e59c095aefeaL570-R569) [[8]](diffhunk://#diff-c0297ddf498b772ae8691ed5a45f3e398e33252716645fa2d9d1e59c095aefeaL596-R595)

**Expanded model registry:**

* Added formal entries for `OpenRouter-FC`, `unified-oss-fc`, and `unified-oss-jsonschema` to the model registry, with appropriate handler assignments and metadata, making these models selectable and configurable for both API and local inference. [[1]](diffhunk://#diff-a051eec72f3cad54df506f8ad9d7cc26481778da2bd9bc59f7c44d20ad0e19d0R125-R136) [[2]](diffhunk://#diff-a051eec72f3cad54df506f8ad9d7cc26481778da2bd9bc59f7c44d20ad0e19d0R1197-R1220)

**Generator configuration and compatibility:**

* Unified generator configuration loading to use the `generator` section from configuration files, supporting new options and improving compatibility across handler types.

**Miscellaneous:**

* Adjusted the default number of threads for `bfcl` in `base_config.yaml` to optimize resource usage.
* Minor cleanup in handler initialization and model name processing for `OpenRouterHandler`.

Let me know if you need details about any specific change or how these improvements affect your workflow!