### PR TITLE
feat: Add YAML-configurable HTTP timeouts for OpenAI/Azure clients with relaxed defaults

### DIFF
--- a/configs/base_config.yaml
+++ b/configs/base_config.yaml
@@ -6,6 +6,29 @@ wandb:
 testmode: false
 inference_interval: 0 # seconds
 
+network:
+  http_timeout:
+    connect: 10.0
+    read: 300.0
+    write: 300.0
+    pool: 30.0
+
+# API個別の上書き（必要に応じて）
+openai:
+  http_timeout:
+    connect: 10.0
+    read: 300.0
+    write: 300.0
+    pool: 30.0
+
+# Azure OpenAI個別
+azure_openai:
+  http_timeout:
+    connect: 10.0
+    read: 300.0
+    write: 300.0
+    pool: 30.0
+
 run:
   jaster: true 
   jmmlu_robustness: true # if this is set as true, jaster should set as true


### PR DESCRIPTION
### PR description
#### 背景 / Motivation
- ARC-AGI実行中に、gpt-4o-miniでAPI応答待ちが30秒を超えやすく、`APITimeoutError` が頻発していた。
- 既存実装ではOpenAI Chat CompletionsのHTTPタイムアウトが固定（read=30s）で、混雑・レート制限・遅延に弱い。
- 設定で柔軟に延長・調整できるよう、YAMLから上書き可能に。

#### 変更概要 / What’s changed
- 緩めのデフォルトタイムアウトを導入（connect=10s, read=300s, write=300s, pool=30s）。
- YAMLからの上書きルール（優先順位）を実装:
  - `openai.http_timeout` または `azure_openai.http_timeout` が最優先
  - なければ `network.http_timeout`
  - それもなければ緩めデフォルト
- 適用対象クライアント:
  - `OpenAIClient`（Chat Completions）
  - `OpenAIResponsesClient`（Responses API）
  - `AzureOpenAIClient`（Chat Completions）
  - `AzureOpenAIResponsesClient`（Responses API）
- 新規関数 `_resolve_http_timeout_from_cfg(cfg, primary_key)` を追加し、各クライアント初期化で利用。

#### 具体的な設定例 / Config examples
- グローバル既定（`configs/base_config.yaml`）

  ```yaml
  network:
    http_timeout:
      connect: 10.0
      read: 300.0
      write: 300.0
      pool: 30.0
  
  openai:
    http_timeout:
      connect: 10.0
      read: 300.0
      write: 300.0
      pool: 30.0
  
  azure_openai:
    http_timeout:
      connect: 10.0
      read: 300.0
      write: 300.0
      pool: 30.0
  ```

- モデル個別の上書き（例: `configs/config-gpt-4o-mini-2024-07-18.yaml`）
  ```yaml
  openai:
    http_timeout:
      connect: 10.0
      read: 300.0
      write: 300.0
      pool: 30.0
  ```

#### 影響範囲 / Impact
- デフォルトでタイムアウトが緩和され、混雑時のAPI待ちに強くなる（特にgpt-4o-miniでのタイムアウト頻度低下を期待）。
- サーバ応答が完全に停止した場合、待ち時間は最大でread/write=300sまで延びる可能性がある（設計上のトレードオフ）。必要に応じてYAMLで短縮可能。
- 既存のベンチ実装・評価ロジックに破壊的変更なし。

#### 動作確認 / Validation
- リンター: 新規エラーなし。
- GPT-4o-mini, all categories, testmode, [W&B Run](https://wandb.ai/llm-leaderboard/nejumi-leaderboard4/runs/4ojpjumy)
- GPT-4o-mini, arc-agi only, fullmode, [W&B Run](https://wandb.ai/llm-leaderboard/nejumi-leaderboard4/runs/sphak7r3)

- 重要ポイント
  - OpenAI/AzureクライアントのタイムアウトがYAMLで上書き可能に
  - 緩めのデフォルト（connect 10s / read 300s / write 300s / pool 30s）
  - 既存ロジック非破壊、リンターOK