### PR TITLE
Revert rollbacked generator config

### DIFF
--- a/configs/base_config.yaml
+++ b/configs/base_config.yaml
@@ -111,7 +111,7 @@ toxicity:
   artifact_path: 'llm-leaderboard/nejumi-leaderboard4-private/toxicity_dataset_full:production'
   judge_prompts_path: 'llm-leaderboard/nejumi-leaderboard4-private/toxicity_judge_prompts:production'
   generator_config:
-    max_tokens: 256
+    max_tokens: 1024
     temperature: 0.0
     top_p: 1.0
   judge:
@@ -136,6 +136,9 @@ swebench:
   prebuild_images: true
 
 mtbench:
+  generator_config:
+    max_tokens: 1024
+    temperature: 0.7
   temperature_override:
     writing: 0.7
     roleplay: 0.7
@@ -152,19 +155,6 @@ mtbench:
   judge_prompt_artifacts_path: 'llm-leaderboard/nejumi-leaderboard4/mtbench_ja_prompt:production' 
   bench_name: 'japanese_mt_bench'
   model_id: null # cannot use '<', '>', ':', ''', '/', '\\', '|', '?', '*', '.'
-  question_begin: null 
-  question_end: null 
-  max_new_token: 1024
-  num_choices: 1
-  num_gpus_per_model: 1
-  num_gpus_total: 1
-  max_gpu_memory: null
-  dtype: float16 # None or float32 or float16 or bfloat16
-  # for gen_judgment
-  judge_model: 'gpt-4o-2024-05-13'
-  mode: 'single'
-  baseline_model: null 
-  parallel: 80
   first_n: null
   judge:
     model: 'gpt-4.1-2025-04-14'
@@ -209,8 +199,9 @@ hallulens:
 hle:
   artifact_path: 'llm-leaderboard/nejumi-leaderboard4/hle-ja:production'
   dataset_name: 'hle-ja.jsonl'
-  max_completion_tokens: 4096
   max_samples: 10
+  generator_config:
+    max_tokens: 4096
   judge:
     model: "o3-mini-2025-01-31"
     parallel: 32


### PR DESCRIPTION
推論共通化時のmtbench, hle, toxicityのconfig変更がロールバックされていたので再適用
https://github.com/wandb/llm-leaderboard/pull/296/files#diff-6c274cd745c998c5c4673e7b0aa803182c9eef7c6b2c618ad93dffd0c3cc2960

toxicityはconfigは残ってますが、モデルによってはちょっと短いので1024に戻しています