### PR TITLE
Grouping weave traces by benchmark

### DIFF
--- a/scripts/evaluator/arc_agi.py
+++ b/scripts/evaluator/arc_agi.py
@@ -9,6 +9,7 @@ from tqdm import tqdm
 import numpy as np
 from PIL import Image
 import wandb
+import weave
 from matplotlib.colors import TABLEAU_COLORS
 
 from config_singleton import WandbConfigSingleton
@@ -219,6 +220,7 @@ def tile_to_img(expected: List[List[int]], output: Optional[List[List[int]]]) ->
     return wandb.Image(pil_image, boxes=bboxes)
 
 
+@weave.op(call_display_name=lambda _: "[ARC-AGI] " + WandbConfigSingleton.get_instance().config.wandb.run_name)
 def evaluate():
     # Retrieve the instance from WandbConfigSingleton and load the W&B run and configuration
     instance = WandbConfigSingleton.get_instance()

--- a/scripts/evaluator/bfcl.py
+++ b/scripts/evaluator/bfcl.py
@@ -7,6 +7,7 @@ import json
 import os
 from typing import Dict, List, Optional, Tuple, Any
 import wandb
+import weave
 import pandas as pd
 from pathlib import Path
 import datetime
@@ -54,6 +55,7 @@ def merge_config(default_config: Dict[str, Any], config: Dict[str, Any]) -> Dict
                 merged[key] = value
     return merged
 
+@weave.op(call_display_name=lambda _: "[BFCL] " + WandbConfigSingleton.get_instance().config.wandb.run_name)
 def evaluate():
     """BFCLの評価を実行する"""
     print("BFCLの評価を開始します")

--- a/scripts/evaluator/hle.py
+++ b/scripts/evaluator/hle.py
@@ -10,6 +10,7 @@ from tqdm.asyncio import tqdm as atqdm
 import pandas as pd
 
 import wandb
+import weave
 
 from config_singleton import WandbConfigSingleton
 from .evaluate_utils import LLMAsyncProcessor, get_openai_judge_client
@@ -335,5 +336,6 @@ async def evaluate_async():
         
         print(f"HLE evaluation for subset '{subset}' completed and logged to wandb")
 
+@weave.op(call_display_name=lambda _: "[HLE] " + WandbConfigSingleton.get_instance().config.wandb.run_name)
 def evaluate():
     asyncio.run(evaluate_async())

--- a/scripts/evaluator/jaster.py
+++ b/scripts/evaluator/jaster.py
@@ -7,6 +7,7 @@ import pandas as pd
 from toolz import pipe
 from tqdm import tqdm
 import wandb
+import weave
 
 from config_singleton import WandbConfigSingleton
 from .evaluate_utils import (
@@ -349,7 +350,8 @@ def evaluate_n_shot(few_shots: bool):
                 f"jmmlu_robust_{num_few_shots}shot_leaderboard_table": leaderboard_robust_table
             }
         )
-        
+
+@weave.op(call_display_name=lambda _: "[BFCL] " + WandbConfigSingleton.get_instance().config.wandb.run_name)
 def evaluate():
     evaluate_n_shot(few_shots=False)
     evaluate_n_shot(few_shots=True)

--- a/scripts/evaluator/jbbq.py
+++ b/scripts/evaluator/jbbq.py
@@ -7,6 +7,7 @@ from tqdm import tqdm
 import pandas as pd
 from toolz import pipe
 from dataclasses import dataclass
+import weave
 
 from config_singleton import WandbConfigSingleton
 from .evaluate_utils import (
@@ -372,6 +373,7 @@ def evaluate_n_shot(few_shots: bool):
         }
     )
 
+@weave.op(call_display_name=lambda _: "[JBBQ] " + WandbConfigSingleton.get_instance().config.wandb.run_name)
 def evaluate():
     #evaluate_n_shot(few_shots=False)
     evaluate_n_shot(few_shots=True)

--- a/scripts/evaluator/jtruthfulqa.py
+++ b/scripts/evaluator/jtruthfulqa.py
@@ -1,5 +1,6 @@
 import json
 import wandb
+import weave
 import pandas as pd
 import torch
 from tqdm import tqdm
@@ -45,6 +46,7 @@ class RoBERTaEvaluator:
         probabilities = torch.nn.functional.softmax(outputs.logits, dim=-1)
         return probabilities[0][1].item()
 
+@weave.op(call_display_name=lambda _: "[JTruthfulQA] " + WandbConfigSingleton.get_instance().config.wandb.run_name)
 def evaluate():
     instance = WandbConfigSingleton.get_instance()
     run = instance.run

--- a/scripts/evaluator/m_ifeval.py
+++ b/scripts/evaluator/m_ifeval.py
@@ -6,6 +6,7 @@ import pandas as pd
 from toolz import pipe
 from tqdm import tqdm
 import wandb
+import weave
 import sys
 import os
 
@@ -62,6 +63,7 @@ def evaluate_m_ifeval(input_data, output_data):
     
     return instruction_correct / instruction_total
 
+@weave.op(call_display_name=lambda _: "[M-IFEval] " + WandbConfigSingleton.get_instance().config.wandb.run_name)
 def evaluate():
     """M-IFEval評価のためのresponse生成"""
     # Retrieve the instance from WandbConfigSingleton and load the W&B run and configuration

--- a/scripts/evaluator/mtbench.py
+++ b/scripts/evaluator/mtbench.py
@@ -6,6 +6,7 @@ import asyncio
 import numpy as np
 import pandas as pd
 import wandb
+import weave
 from dataclasses import dataclass, field
 from typing import List, Dict, Any, Optional, Tuple, Literal, Awaitable
 import shortuuid
@@ -536,6 +537,7 @@ async def async_evaluate():
     print("MT-Bench評価が正常に完了しました！")
     return
 
+@weave.op(call_display_name=lambda _: "[MT-Bench] " + WandbConfigSingleton.get_instance().config.wandb.run_name)
 def evaluate():
     """非同期評価関数を実行するエントリーポイント"""
     asyncio.run(async_evaluate()) 

--- a/scripts/evaluator/swe_bench.py
+++ b/scripts/evaluator/swe_bench.py
@@ -11,6 +11,7 @@ from functools import partial
 import multiprocessing as mp
 import pandas as pd
 import wandb
+import weave
 from tqdm import tqdm
 import subprocess
 import os
@@ -533,6 +534,7 @@ def run_swebench_evaluation(predictions_file: Path, max_workers: int = 4, instan
     
     return result
 
+@weave.op(call_display_name=lambda _: "[SWE-Bench] " + WandbConfigSingleton.get_instance().config.wandb.run_name)
 def evaluate():
     """SWE-bench評価メイン関数"""
     instance = WandbConfigSingleton.get_instance()

--- a/scripts/evaluator/toxicity.py
+++ b/scripts/evaluator/toxicity.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd
 import wandb
+import weave
 from tqdm.asyncio import tqdm as atqdm
 from config_singleton import WandbConfigSingleton
 from .evaluate_utils import LLMAsyncProcessor, get_openai_judge_client
@@ -221,5 +222,6 @@ async def evaluate_async():
         "toxicity_radar_table":toxicity_radar,
     })
 
+@weave.op(call_display_name=lambda _: "[Toxicity] " + WandbConfigSingleton.get_instance().config.wandb.run_name)
 def evaluate():
     asyncio.run(evaluate_async())


### PR DESCRIPTION
Weaveのtracesをベンチマーク単位でネストしてグルーピングするように変更

https://wandb.ai/llm-leaderboard/nejumi-leaderboard4/weave/traces
Filterで `op: evaluate` にすると確認できます

<img width="1398" height="803" alt="image" src="https://github.com/user-attachments/assets/cce5a098-6568-4b3c-be4e-ac50b5b5d74d" />
