### PR TITLE
README aligned with existing .env + run_with_compose.sh flow; structured logs; max_tokens checks; add model YAMLs and SWE-Bench EN doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,31 +4,28 @@
 This repository is for the Nejumi Leaderboard 4, a comprehensive evaluation platform for large language models. The leaderboard assesses both general language capabilities and alignment aspects. For detailed information about the leaderboard, please visit [Nejumi Leaderboard](https://wandb.ai/wandb-japan/llm-leaderboard4/reports/Nejumi-LLM-4--Vmlldzo5NTI0MDI0) website.
 
 ## Evaluation Metrics
-Our evaluation framework incorporates a diverse set of metrics to provide a holistic assessment of model performance:
+Our evaluation framework incorporates a diverse set of metrics to provide a holistic assessment of model performance.
 
-| Main Category | Subcategory | Automated Evaluation with Correct Data | AI Evaluation | Note |
-|---------------|-------------|----------------------------------------|---------------|------|
-| General Language Processing | Expression | | MT-bench/roleplay (0shot)<br>MT-bench/humanities (0shot)<br>MT-bench/writing (0shot) | |
-| ^ | Translation | ALT e-to-j (jaster) (0shot, 2shot)<br>ALT j-to-e (jaster) (0shot, 2shot)<br>wikicorpus-e-to-j(jaster) (0shot, 2shot)<br>wikicorpus-j-to-e(jaster) (0shot, 2shot) | | |
-| ^ | Summarization | | | |
-| ^ | Information Extraction | JSQuaD (jaster) (0shot, 2shot) | | |
-| ^ | Reasoning | | MT-bench/reasoning (0shot) | |
-| ^ | Mathematical Reasoning | MAWPS*(jaster) (0shot, 2shot)<br>MGSM*(jaster) (0shot, 2shot) | MT-bench/math (0shot) | |
-| ^ | (Entity) Extraction | wiki_ner*(jaster) (0shot, 2shot)<br>wiki_coreference(jaster) (0shot, 2shot)<br>chABSA*(jaster) (0shot, 2shot) | MT-bench/extraction (0shot) | |
-| ^ | Knowledge / Question Answering | JCommonsenseQA*(jaster) (0shot, 2shot)<br>JEMHopQA*(jaster) (0shot, 2shot)<br>JMMLU*(0shot, 2shot)<br>NIILC*(jaster) (0shot, 2shot)<br>aio*(jaster) (0shot, 2shot) | MT-bench/stem (0shot) | |
-| ^ | semantic analysis | JNLI*(jaster) (0shot, 2shot)<br>JaNLI*(jaster) (0shot, 2shot)<br>JSeM*(jaster) (0shot, 2shot)<br>JSICK*(jaster) (0shot, 2shot)<br>Jamp*(jaster) (0shot, 2shot) | | |
-| ^ | syntactic analysis | JCoLA-in-domain*(jaster) (0shot, 2shot)<br>JCoLA-out-of-domain*(jaster) (0shot, 2shot)<br>JBLiMP*(jaster) (0shot, 2shot)<br>wiki_reading*(jaster) (0shot, 2shot)<br>wiki_pas*(jaster) (0shot, 2shot)<br>wiki_dependency*(jaster) (0shot, 2shot) | | |
-| ^ | Code Generation | SWE-bench (full) <br> BFCL (Code Generation) <br> HumanEval-ja (jaster) | | |
-| ^ | Tool Usage | BFCL (Tool Usage) | | |
-| ^ | Instruction Following | M-IFEval | | |
-| ^ | Logical Reasoning | ARC-AGI | | |
-| Alignment | Controllability | jaster* (0shot, 2shot)<br> | | |
-| ^ | Ethics/Moral | JCommonsenseMorality*(2shot) | | |
-| ^ | Toxicity || LINE Yahoo Reliability Evaluation Benchmark | This dataset is not publicly available due to its sensitive content.| <TBU> |
-| ^ | Bias | JBBQ (2shot) | | JBBQ needs to be downloaded from [JBBQ github repository](https://github.com/ynklab/JBBQ_data?tab=readme-ov-file). |
-| ^ | Truthfulness | JTruthfulQA | HalluLens | For JTruthfulQA evaluation, nlp-waseda/roberta_jtruthfulqa requires Juman++ to be installed beforehand. You can install it by running the script/install_jumanpp.sh script. |
-| ^ | Robustness | Test multiple patterns against JMMLU (W&B original) (0shot, 2shot)<br>- Standard method<br>- Choices are symbols<br>- Select anything but the correct answer | | |
-| ^ | Factuality & Faithfulness | HLE-JA | | |
+| Main Category | Category | Subcategory | Benchmarks | Details | Weight (within GLP) |
+|---------------|----------|-------------|------------|---------|----------------------|
+| General Language Performance (GLP) | Applied Language Skills | Expression | MT-bench (roleplay, writing, humanities) | Roleplay, writing, humanities | 1 |
+| ^ | Applied Language Skills | Translation | Jaster (ALT e-to-j, ALT j-to-e) | JA↔EN translation (averaged over 0-shot and few-shot) | 1 |
+| ^ | Applied Language Skills | Information Retrieval (QA) | Jaster (JSQuAD) | Japanese QA (averaged over 0-shot and few-shot) | 1 |
+| ^ | Reasoning | Abstract Reasoning | ARC-AGI | Abstract pattern recognition (arc-agi-1 / arc-agi-2) | 2 |
+| ^ | Reasoning | Logical Reasoning | MT-bench (reasoning) | Logical reasoning tasks | 2 |
+| ^ | Reasoning | Mathematical Reasoning | Jaster (MAWPS, MGSM), MT-bench (math) | Math word problems, mathematical reasoning | 2 |
+| ^ | Knowledge & QA | General Knowledge | Jaster (JCommonsenseQA, JEMHopQA, NIILC, AIO), MT-bench (STEM) | Commonsense reasoning, multi-hop QA, basic STEM knowledge | 2 |
+| ^ | Knowledge & QA | Specialized Knowledge | Jaster (JMMLU, MMLU_Prox_JA), HLE | Domain knowledge evaluation (incl. PhD-level: medicine, law, engineering) | 2 |
+| ^ | Foundational Language Skills | Semantic Analysis | Jaster (JNLI, JaNLI, JSeM, JSICK, JAMP) | Natural language inference, semantic similarity | 1 |
+| ^ | Foundational Language Skills | Syntactic Analysis | Jaster (JCoLA-in-domain, JCoLA-out-of-domain, JBLiMP) | Grammatical acceptability | 1 |
+| ^ | Application Development | Coding | SWE-Bench, JHumanEval, MT-bench (coding) | Practical coding ability, code generation | 2 |
+| ^ | Application Development | Function Calling | BFCL | Function calling accuracy (single/multi-turn, irrelevant detection) | 2 |
+| Alignment (ALT) | Controllability | Controllability | Jaster Control, M-IFEVAL | Instruction following, constraint adherence | 1 |
+| ^ | Ethics & Morality | Ethics & Morality | Jaster (CommonsenseMoralityJA) | Ethical and moral judgement | 1 |
+| ^ | Safety | Toxicity | Toxicity | Fairness, social norms, prohibited behavior, violation categories | 1 |
+| ^ | Bias | Bias | JBBQ | Japanese bias benchmark (1 - avg_abs_bias_score) | 1 |
+| ^ | Truthfulness | Truthfulness | JTruthfulQA, HalluLens | Factuality assessment, hallucination suppression (refusal rate) | 1 |
+| ^ | Robustness | Robustness | JMMLU Robust | Consistency and robustness under varied question formats | 1 |
 
 
 - metrics with (0, 2-shot) are averaged across both settings.
@@ -40,44 +37,50 @@ Our evaluation framework incorporates a diverse set of metrics to provide a holi
 ## Implementation Guide
 
 ### Environment Setup
-1. Set up environment variables
-```
-export WANDB_API_KEY=<your WANDB_API_KEY>
-export OPENAI_API_KEY=<your OPENAI_API_KEY>
-export LANG=ja_JP.UTF-8
-# if you use OpenRouter as OpenAI compatible api inference,
-export OPENAI_COMPATIBLE_API_KEY=<your Open Router AI> 
-# If using Azure OpenAI instead of standard OpenAI
-export AZURE_OPENAI_ENDPOINT=<your AZURE_OPENAI_ENDPOINT>
-export AZURE_OPENAI_API_KEY=<your AZURE_OPENAI_API_KEY>
-export OPENAI_API_TYPE=azure
-# if needed, set the following API KEY too
-export ANTHROPIC_API_KEY=<your ANTHROPIC_API_KEY>
-export GOOGLE_API_KEY=<your GOOGLE_API_KEY>
-export COHERE_API_KEY=<your COHERE_API_KEY>
-export MISTRAL_API_KEY=<your MISTRAL_API_KEY>
-export AWS_ACCESS_KEY_ID=<your AWS_ACCESS_KEY_ID>
-export AWS_SECRET_ACCESS_KEY=<your AWS_SECRET_ACCESS_KEY>
-export AWS_DEFAULT_REGION=<your AWS_DEFAULT_REGION>
-export UPSTAGE_API_KEY=<your UPSTAGE_API_KEY>
-export HUGGINGFACE_HUB_TOKEN=<your HUGGINGFACE_HUB_TOKEN>
-# if needed, please login in huggingface
-huggingface-cli login
-```
-
-2. Clone the repository
+1. Clone the repository
 ```bash
 git clone https://github.com/wandb/llm-leaderboard.git
 cd llm-leaderboard
 ```
 
-3. Build Docker images
-```bash
-# Build the evaluation container
-docker build -t llm-stack-llm-leaderboard:latest .
+2. Create a `.env` file in the repository root
+```
+WANDB_API_KEY=
+OPENAI_API_KEY=
+LANG=ja_JP.UTF-8
+# OpenAI compatible (e.g. OpenRouter / vLLM Gateway)
+OPENAI_COMPATIBLE_API_KEY=
 
-# Create Docker network (first time only)
-docker network create llm-stack-network
+# Azure OpenAI (use if you evaluate via Azure)
+AZURE_OPENAI_ENDPOINT=
+AZURE_OPENAI_API_KEY=
+OPENAI_API_TYPE=azure
+
+# Other API keys (set as needed)
+ANTHROPIC_API_KEY=
+GOOGLE_API_KEY=
+COHERE_API_KEY=
+MISTRAL_API_KEY=
+UPSTAGE_API_KEY=
+XAI_API_KEY=
+DEEPSEEK_API_KEY=
+
+# Hugging Face
+HUGGINGFACE_HUB_TOKEN=
+HF_TOKEN=${HUGGINGFACE_HUB_TOKEN}
+
+# (Optional) AWS for Bedrock family
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_DEFAULT_REGION=
+
+# (Optional) SWE-bench server key
+SWE_API_KEY=
+```
+
+3. (First time only) Create Docker network
+```bash
+docker network create llm-stack-network || true
 ```
 
 ### Dataset Preparation
@@ -106,9 +109,7 @@ In Nejumi Leadeboard4, the following dataset are used.
 
 #### Base configuration
 
-The `base_config.yaml` file contains basic settings, and you can create a separate YAML file for model-specific settings. This allows for easy customization of settings for each model while maintaining a consistent base configuration.
-
-Below, you will find a detailed description of the variables utilized in the `base_config.yaml` file.
+The `configs/base_config.yaml` file contains the shared settings. Create per-model YAMLs under `configs/` that override only the necessary parts. Below are key sections used in this repository (names and placement reflect the actual file structure):
 
 - **wandb:** Information used for Weights & Biases (W&B) support.
     - `entity`: Name of the W&B Entity.
@@ -117,15 +118,14 @@ Below, you will find a detailed description of the variables utilized in the `ba
 - **testmode:** Default is false. Set to true for lightweight implementation with a small number of questions per category (for functionality checks).
 - **inference_interval:** Set inference interval in seconds. This is particularly effective when there are rate limits, such as with APIs.
 - **run:** Set to true for each evaluation dataset you want to run.
-- **model:** Information about the model.
-    - `artifacts_path`: Path of the wandb artifacts where the model is located.
-    - `max_model_len`: Maximum token length of the input.
-    - `chat_template`: Path to the chat template file. This is required for open-weights models.
-    - `dtype`: Data type. Choose from float32, float16, bfloat16.
-    - `trust_remote_code`:  Default is true.
-    - `device_map`: Device map. Default is "auto".
-    - `load_in_8bit`: 8-bit quantization. Default is false.
-    - `load_in_4bit`: 4-bit quantization. Default is false.
+- **model:** Model metadata (kept minimal in base; overrides go in each model config).
+    - `artifacts_path`: Path of the W&B artifact if loading models from artifacts (optional).
+
+- **vllm:** vLLM launch parameters (only used for open‑weights via vLLM).
+    - `vllm_tag`: Docker image tag for vLLM (default: latest).
+    - `disable_triton_mma`: Workaround for older GPUs.
+    - `lifecycle`: Container lifecycle policy.
+    - `dtype`, `max_model_len`, `device_map`, `gpu_memory_utilization`, `trust_remote_code`, `chat_template`, `extra_args`: vLLM-specific options.
 
 - **generator:** Settings for generation. For more details, refer to the [generation_utils](https://huggingface.co/docs/transformers/internal/generation_utils) in Hugging Face Transformers.
     - `top_p`: top-p sampling. Default is 1.0.
@@ -160,13 +160,15 @@ Below, you will find a detailed description of the variables utilized in the `ba
     - `artifact_path`: URL of the WandB Artifact for the JTruthfulQA dataset.
     - `roberta_model_name`: Name of the RoBERTa model used for evaluation. Default is 'nlp-waseda/roberta_jtruthfulqa'.
 
-- **swebench:** Settings for the SWE-bench dataset.
+- **swebench:** Settings for the SWE-bench dataset (matches `configs/base_config.yaml`).
     - `artifacts_path`: URL of the WandB Artifact for the SWE-bench dataset.
     - `dataset_dir`: Directory of the SWE-bench dataset after downloading the Artifact.
     - `max_samples`: Number of samples to use for evaluation.
     - `max_tokens`: Maximum number of tokens to generate.
     - `max_workers`: Number of workers for parallel processing.
     - `evaluation_method`: Choose 'official' or 'docker'.
+    - `fc_enabled`: Enable function calling to enforce unified diff output.
+    - `api_server`: Remote evaluation settings (`enabled`, `endpoint`, `api_key`, `timeout_sec`).
 
 - **mtbench:** Settings for the MT-Bench evaluation.
     - `temperature_override`: Override the temperature for each category of the MT-Bench.
@@ -220,12 +222,12 @@ This framework supports evaluating models using APIs such as OpenAI, Anthropic, 
     - `run_name`: Name of the W&B run.
 - **api:** Choose the API to use from `openai`, `anthropic`, `google`, `amazon_bedrock`.
 - **batch_size:** Batch size for API calls (recommended: 32).
-- **model:** Information about the model. 
-    - `pretrained_model_name_or_path`: Name of the API model.
-    - `size_category`: Specify "api" to indicate using an API model.
-    - `size`: Model size (leave as null for API models).
-    - `release_date`: Model release date. (MM/DD/YYYY)
-    - `bfcl_model_name`: Please select from scripts/evaluator/evaluate_utils/bfcl_pkg/SUPPORTED_MODELS.md. To simplify model addition, Nejumi Leaderboard provides common handlers for each API type, such as OpenAI-FC and claude-FC. By using these handlers, you do not need to add entries to model_config for each new model.
+- **model:** Information about the API model. 
+    - `pretrained_model_name_or_path`: API model name (e.g., `gpt-5-2025-08-07`).
+    - `size_category`: Use `api`.
+    - `size`: Leave as null for API models.
+    - `release_date`: Model release date (MM/DD/YYYY).
+    - `bfcl_model_id`: Select an ID from `scripts/evaluator/evaluate_utils/bfcl_pkg/SUPPORTED_MODELS.md` or use a common handler (e.g., `OpenAIResponsesHandler-FC`).
 
 #### Other Model Configurations
 
@@ -276,55 +278,38 @@ If the model ID and chat_template are the same, you can omit -c <chat_template>.
 ## Evaluation Execution
 Once you prepare the dataset and the configuration files, you can run the evaluation process.
 
-### Using Docker Compose (Recommended)
+### Using Docker Compose
 
-The simplest way to run evaluations is using the `run_with_compose.sh` script:
-
-```bash
-# Make the script executable (first time only)
-chmod +x run_with_compose.sh
-
-# Run evaluation with model name or config file
-./run_with_compose.sh gpt-4o-2024-05-13
-./run_with_compose.sh Meta-Llama-3-8B-Instruct
-./run_with_compose.sh config-Meta-Llama-3-8B-Instruct.yaml
-
-# With debug mode
-./run_with_compose.sh Meta-Llama-3-8B-Instruct -d
-```
-
-This script automatically:
-- Sets up necessary Docker services (SSRF proxy, Dify sandbox)
-- Starts vLLM container if needed (for vLLM models)
-- Runs the evaluation
-- Optionally stops vLLM container after completion
-
-### Manual Execution
-
-You can use either `-c` or `-s` option:
-- **-c (config):** Specify the config file by its name, e.g., `python3 scripts/run_eval.py -c config-gpt-4o-2024-05-13.yaml`
-- **-s (select-config):** Select from a list of available config files. This option is useful if you have multiple config files. 
-```bash
-# Direct execution (requires proper environment setup)
-python3 scripts/run_eval.py -s
-# or 
-python3 scripts/run_eval.py -c config-gpt-4o-2024-05-13.yaml
-```
-
-### Using Docker Compose Commands Directly
-
-For more control, you can use Docker Compose commands directly:
+Basic flow (requires `.env` and a model YAML under `configs/`):
 
 ```bash
-# Start all necessary services
-docker compose up -d ssrf-proxy dify-sandbox
+# 1) Create the network once (safe if it already exists)
+docker network create llm-stack-network || true
 
-# For vLLM models
-docker compose --profile vllm-docker up -d vllm
+# 2) Run the evaluation (example: OpenAI o3 config)
+bash ./run_with_compose.sh config-o3-2025-04-16.yaml
 
-# Run evaluation
-docker compose run --rm llm-leaderboard
+# Add -d to see more debug output
+# bash ./run_with_compose.sh config-o3-2025-04-16.yaml -d
 ```
+
+The script does the following automatically:
+- Starts **ssrf-proxy** and **dify-sandbox**
+- If the target is a **vLLM** model, starts the vLLM container and waits for readiness
+- Runs `scripts/run_eval.py -c <your YAML>` inside the evaluation container
+
+### Manual Execution (Advanced / Optional)
+
+Use only if you want to run directly without `run_with_compose.sh`.
+- **-c (config):** `python3 scripts/run_eval.py -c config-gpt-4o-2024-05-13.yaml`
+- **-s (select-config):** `python3 scripts/run_eval.py -s`
+
+### SWE-Bench and API Server Docs
+
+For SWE‑Bench evaluation details and the remote evaluation API server, see:
+
+- `docs/README_swebench_ja.md` (dataset creation, prompts, patch rules)
+- `scripts/evaluator/evaluate_utils/swebench_pkg/swebench_api_server.md` (API server runbook)
 
 ### Troubleshooting
 
@@ -348,7 +333,7 @@ If BFCL evaluation fails with model name mismatches:
 The results of the evaluation will be logged to the specified W&B project.
 
 ## When you want to edit runs or add additional evaluation metrics
-Please refer to [belend_run_configs/README.md](blend_run_configs/README.md).
+Refer to the in-repo docs above or open an issue/PR. The previously referenced `blend_run_configs` guide is not used in this repository.
 
 
 

--- a/configs/config-o3-2025-04-16.yaml
+++ b/configs/config-o3-2025-04-16.yaml
@@ -1,5 +1,5 @@
 wandb:
-  run_name: openai/o3-2025-04-16
+  run_name: "openai/o3-2025-04-16: high-effort"
 api: openai_responses # openai, anthropic, google,..
 batch_size: 32
 model:
@@ -10,13 +10,51 @@ model:
   size: null
   release_date: 4/16/2025 # format: MM/DD/YYYY
 
-generator:
-  # temperature は外す（o3 は非対応）
-  max_output_tokens: 800000  
-  reasoning:
-    effort: "high"          # "low" | "medium" | "high"
-    summary: "auto"        
-  include:
-    - "reasoning.encrypted_content"
+
+generator: # LLM client default configuration: to be overridden by each benchmark
+  max_tokens: 100000
   parallel_tool_calls: true
-  temparature: None
+  extra_body:
+    reasoning:
+      effort: high
+
+jaster:
+  override_max_tokens: 100000 # if null, use value defined in task dataset files
+
+jbbq:
+  generator_config:
+    max_tokens: 100000
+
+toxicity:
+  generator_config:
+    max_tokens: 100000
+
+jtruthfulqa:
+  generator_config:
+    max_tokens: 100000
+
+swebench:
+  max_tokens: 100000
+
+mtbench:
+  generator_config:
+    max_tokens: 100000
+
+bfcl:
+  generator_config:
+    max_tokens: 100000
+
+hallulens:
+  generator_config:
+    max_tokens: 100000
+
+hle:
+  generator_config:
+    max_tokens: 100000
+
+arc_agi:
+  max_output_tokens: 100000
+
+m_ifeval:
+  generator_config:
+    max_tokens: 100000

--- a/configs/config-plamo-2.0-prime.yaml
+++ b/configs/config-plamo-2.0-prime.yaml
@@ -1,0 +1,22 @@
+wandb:
+  run_name: "plamo-2.0-prime: function-calling-evaluation"
+
+# PLaMo API is OpenAI compatible
+# Environment variable: OPENAI_COMPATIBLE_API_KEY should be set to your PLAMO_API_KEY
+api: openai-compatible
+base_url: "https://api.platform.preferredai.jp/v1"
+batch_size: 32
+
+model:
+  pretrained_model_name_or_path: "plamo-2.0-prime"  # API model name
+  bfcl_model_id: "PLaMo-2.0-Prime-FC"  # Custom BFCL model ID for function calling mode
+  base_model: "unknown"
+  size_category: api
+  size: null
+  release_date: "05/22/2025"  # Approximate release date
+
+# Generator configuration - Minimal parameters for PLaMo compatibility
+generator:
+  max_tokens: 4096  # PLaMo max output tokens
+  temperature: 0.1   # PLaMo default
+  top_p: 0.9         # PLaMo default

--- a/docs/README_swebench.md
+++ b/docs/README_swebench.md
@@ -1,0 +1,222 @@
+# SWE-Bench Evaluation Guide (Nejumi LLM Leaderboard 4)
+
+**TL;DR**
+
+* **What do we measure?**
+  For real OSS “bug-fixing tasks,” the model generates a unified diff. We apply it and automatically grade based on whether all official tests pass.
+* **Verified subset**
+  We use a stable subset with curated inputs, environments, and expected tests. From the Japanese version `nejumi/swe-bench-verified-ja`, we sample 80 instances under 7,000 input tokens.
+* **Most critical output constraint**
+  The unified diff must include line numbers in the @@ hunk headers (`@@ -start,count +start,count @@`). Missing them causes patch application to fail.
+
+---
+
+## 1. What is SWE-Bench?
+
+* **Overview**: An end-to-end benchmark based on real bug fixes in OSS repositories.
+  Input (Issue/PR context, relevant file snippets, reproduction tests, etc.) → Output (the unified diff patch).
+  After applying the patch and running tests, the instance is considered Resolved if all tests pass.
+
+* **Verified**:
+  A stable subset with curated inputs, environments, and expected tests for higher reproducibility and grading reliability.
+
+---
+
+## 2. How we build this 80-instance evaluation set
+
+* **Objective**: Make it feasible for local LLMs (~8k context) by ensuring inputs are under 7,000 tokens, while preserving the original (500 instances) difficulty distribution and staying close to GPT-4.1’s resolved ratio.
+
+* **Base**: `nejumi/swe-bench-verified-ja` (500 instances, `problem_statement` and `hint_text` translated into Japanese with Qwen/Qwen3-235B-A22B)
+
+* **Filter**: Approximate token counts using `hf-internal-testing/llama-tokenizer` (equivalent to Llama 2), and keep only `num_tokens < 7000`.
+
+* **Sampling**: Stratified by `(difficulty, status)`
+
+  * `difficulty`: 4 levels
+  * `status`: resolved / not resolved
+
+* **Prompt shaping**:
+  We embed a CRITICAL sentence before the string "I need you to solve the provided issue" within `text`, enforcing "line numbers required in @@ hunk header".
+
+* **Distribution**: W&B Artifact (Arrow format)
+
+  * Name: `swebench_verified_official` (versioned)
+  * This evaluation uses the 80-instance subset
+
+---
+
+## 3. Distribution comparison (Original 500 vs 80)
+
+| Metric            | Original (500) | 80 (<7k) |
+| ----------------- | -------------: | -------: |
+| <15 min fix       |          38.8  |     46.2 |
+| 15 min – 1 hour   |          52.2  |     50.0 |
+| 1–4 hours         |           8.4  |      3.8 |
+| >4 hours          |           0.6  |      0.0 |
+| Resolved rate     |          34.6  |     37.5 |
+
+**Notes**: Slight increase in short fixes (<15 min), and reductions in 1–4 hours and >4 hours.
+The **Resolved rate** is similar (34.6% → 37.5%), maintaining overall trends well.
+
+---
+
+## 4. End-to-end evaluation flow (overview)
+
+```
+┌────────────────────────────┐
+│ Dataset (80 items)         │
+└───────────────┬────────────┘
+                │ Input (Issue/PR context, relevant snippets,
+                │         reproduction/expected tests, constraints)
+                ▼
+┌────────────────────────────────────────┐
+│ Generation (LLM)                       │
+│  - Prompt shaping (CRITICAL sentence)  │
+│  - fc_enabled: enforce unified diff    │
+└───────────────────┬────────────────────┘
+                    │ Unified diff (line numbers in @@ required)
+                    ▼
+┌────────────────────────────────────────┐
+│ Preprocessing (expansion & normalization) │
+│  - Extract minimal patch                │
+│  - Hunk header expansion                │
+│  - Filename normalization / merge dups  │
+└───────────────────┬────────────────────┘
+                    │ Apply patch (git apply / patch --fuzz)
+                    ▼
+┌────────────────────────────────────────┐
+│ Evaluation runner                      │
+│  - Official or Docker                  │
+│  - Prebuilt images optional            │
+│  - Run unit tests                      │
+└───────────────────┬────────────────────┘
+                    │ Pass/Fail
+                    ▼
+            Resolved / Not Resolved
+                    ↓
+             SWE-Bench Score
+           (Resolved rate = pass rate)
+```
+
+---
+
+## 5. I/O specification (example)
+
+### Input
+
+* Task description (Japanese), relevant file snippets, reproduction/expected tests, constraints
+* Evaluation meta (e.g., `evaluation_method: official|docker`, `prebuild_images: true`)
+
+### Output (unified diff)
+
+```diff
+--- a/astropy/modeling/separable.py
++++ b/astropy/modeling/separable.py
+@@ -245,1 +245,1 @@
+-        cright[-right.shape[0]:, -right.shape[1]:] = 1
++        cright[-right.shape[0]:, -right.shape[1]:] = right
+```
+
+⚠️ **CRITICAL**
+
+* **Line numbers are required in the @@ hunk header**
+* Follow the format `@@ -start,count +start,count @@`
+
+---
+
+## 6. Execution modes and environment
+
+* **Execution environment**: Runs on a fixed Docker image
+* **Generation control**: Adjust temperature and max tokens with `generator.*`
+* **fc_enabled: true** enforces a unified diff output format
+
+---
+
+## 7. Quickstart
+
+### Dependencies
+
+```bash
+./myenv/bin/pip install fastapi "uvicorn[standard]" swebench
+```
+
+### Start the API server
+
+```bash
+nohup ./myenv/bin/python scripts/server/swebench_server.py \
+  --host 0.0.0.0 --port 8000 \
+  >/tmp/swebench_server.out 2>&1 & disown
+```
+
+### Submit a job (example)
+
+```bash
+PATCH_FILE=patch.diff
+INSTANCE_ID=astropy__astropy-12907
+curl -s -H "Content-Type: application/json" \
+     -H "X-API-Key: $SWE_API_KEY" \
+     -d @<(jq -n --arg iid "$INSTANCE_ID" --arg patch "$(cat "$PATCH_FILE")" \
+       '{instance_id:$iid, patch_diff:$patch, namespace:"swebench", tag:"latest", model_name_or_path:"nejumi-api"}') \
+     http://127.0.0.1:8000/v1/jobs
+```
+
+---
+
+## 8. Key configuration items
+
+```yaml
+swebench:
+  artifacts_path: llm-leaderboard/nejumi-leaderboard4/swebench_verified_official:production
+  dataset_dir: swebench_verified_official
+  max_samples: 80
+  max_tokens: 2048
+  max_workers: 4
+  evaluation_method: docker
+  prebuild_images: true
+  fc_enabled: true
+  api_server:
+    enabled: false
+```
+
+---
+
+## 9. Extensions beyond the original SWE-Bench
+
+* **Hunk header expansion**
+
+  * Increase `pre_len` / `post_len` in hunk headers by `ctx*2` (default ctx=5)
+  * We do not insert extra context lines into the patch body; we only increase counts to relax application tolerance
+  * If `git apply` fails, we progressively try `patch --fuzz=10` / `--fuzz=20`
+
+* **Minimal patch extraction**
+
+  * Remove extraneous text and irrelevant diffs; recompute header line numbers
+  * Reduce changes to the minimum necessary for tests to pass
+
+* **CRITICAL sentence insertion**
+
+  * Explicitly enforce "line numbers required in @@ hunk header" to stabilize outputs
+
+---
+
+## 10. Best practices
+
+* **Output only the diff** (no explanatory text mixed in)
+* **Line numbers are mandatory in @@ headers**
+* **Minimal patch principle**
+* Enable `fc_enabled: true`
+
+---
+
+## 11. FAQ
+
+* **Q. What determines Resolved?**
+  → After applying the generated patch, the instance is Resolved if all tests pass.
+
+* **Q. Why hunk header expansion?**
+  → To allow `git apply` to succeed despite minor drifts or whitespace differences.
+  → We increase only the line counts in the header, not the number of actual context lines in the body.
+
+* **Q. When do we use fuzz?**
+  → We try `patch --fuzz=10,20` if `git apply` fails.
+

--- a/docs/README_swebench_ja.md
+++ b/docs/README_swebench_ja.md
@@ -1,0 +1,221 @@
+# SWE-Bench 評価ガイド（Nejumi LLM Leaderboard 4 版）
+
+**TL;DR**
+
+* **何を測る？**
+  実在 OSS の“本物のバグ修正タスク”に対し、モデルが生成した **統一 diff（unified diff）** を適用 → **公式テスト**が全部通るかで自動採点。
+* **Verified サブセット**
+  入力・環境・期待テストが整備済みの安定版。ここでは日本語化した `nejumi/swe-bench-verified-ja` から、**7,000トークン未満の 80 件**を抽出して使用。
+* **最重要の出力制約**
+  生成パッチの **@@ ハンクヘッダには必ず行番号**（`@@ -start,count +start,count @@`）を入れること。これが欠けると適用に失敗。
+
+---
+
+## 1. SWE-Bench とは
+
+* **概要**：OSS リポジトリの **実バグ修正**を題材にした **エンドツーエンド評価ベンチマーク**。
+  **入力**（Issue/PR 文脈、関連ファイル抜粋、再現テスト 等）→ **出力**（統一 diff 形式のパッチ）。
+  パッチを当ててテストを回し、**全テスト合格なら Resolved** と判定。
+
+* **Verified 版**：
+  評価に必要な **入力・環境・期待テスト**が整理され、**再現性と採点の安定性**が高いサブセット。
+
+---
+
+## 2. この評価セット（80 件）の作り方
+
+* **目的**：ローカル LLM（\~8k コンテキスト）でも扱えるよう、**入力 7,000 トークン未満**で揃えつつ、
+  元データ（500 件）の **難易度分布**と **GPT-4.1 の解決率（resolved 率）** にできるだけ近い構成へ。
+
+* **ベース**：`nejumi/swe-bench-verified-ja`（500 件、`problem_statement`と`hint_text`はQwen/Qwen3-235B-A22Bで日本語化）
+
+* **フィルタ**：`hf-internal-testing/llama-tokenizer`（Llama 2 相当）で概算し、`num_tokens < 7000` のみ採用
+
+* **サンプリング**：`(difficulty, status)` を層化キーに抽出
+
+  * `difficulty`: 4 区分
+  * `status`: resolved / not resolved
+
+* **プロンプト整形**：
+  `text` 内の「I need you to solve the provided issue」の直前に、**@@ ハンクヘッダの行番号必須**（CRITICAL 文）を埋め込み済み
+
+* **配布形態**：W\&B アーティファクト（Arrow 形式）
+
+  * 名前：`swebench_verified_official`（バージョンで管理）
+  * 本評価では **80 件版** を使用
+
+---
+
+## 3. 分布の比較（元 500 件 vs 80 件）
+
+| 指標              | 元(500) | 80件(<7k) |
+| --------------- | -----: | -------: |
+| <15 min fix     |   38.8 |     46.2 |
+| 15 min – 1 hour |   52.2 |     50.0 |
+| 1–4 hours       |    8.4 |      3.8 |
+| >4 hours        |    0.6 |      0.0 |
+| Resolved率       |   34.6 |     37.5 |
+
+**所感**：短時間で直る課題（<15 min）がやや増え、1–4 hours と >4 hours は縮小。
+**Resolved 率**は **34.6% → 37.5%** と近似しており、全体傾向の再現性は良好です。
+
+---
+
+## 4. 評価 E2E フロー（全体像）
+
+```
+┌────────────────┐
+│ Dataset (80件) │
+└──────┬─────────┘
+       │ 入力（Issue/PR文脈、関連抜粋、再現/期待テスト、制約）
+       ▼
+┌───────────────────────────────┐
+│ 生成 (LLM)                     │
+│  - prompt 整形（CRITICAL文）   │
+│  - fc_enabled: 統一diffを強制  │
+└──────────┬────────────────────┘
+           │ 統一diff（@@ 行番号必須）
+           ▼
+┌───────────────────────────────┐
+│ 前処理（拡張 & 正規化）         │
+│  - Minimal patch 抽出           │
+│  - ハンクヘッダ拡張             │
+│  - ファイル名正規化/重複マージ  │
+└──────────┬────────────────────┘
+           │ パッチ適用（git apply / patch --fuzz）
+           ▼
+┌───────────────────────────────┐
+│ 評価ランナー                    │
+│  - 公式 or Docker               │
+│  - 事前ビルドイメージ使用可     │
+│  - ユニットテスト実行           │
+└──────────┬────────────────────┘
+           │ 成否
+           ▼
+     Resolved / Not Resolved
+             ↓
+       SWE-Bench スコア
+   （Resolved 率 = 合格率）
+```
+
+---
+
+## 5. 入出力仕様（実例）
+
+### 入力
+
+* 課題説明（日本語化済み）、関連ファイル抜粋、再現/期待テスト、制約
+* 評価環境メタ（`evaluation_method: official|docker`、`prebuild_images: true` 等）
+
+### 出力（統一 diff）
+
+```diff
+--- a/astropy/modeling/separable.py
++++ b/astropy/modeling/separable.py
+@@ -245,1 +245,1 @@
+-        cright[-right.shape[0]:, -right.shape[1]:] = 1
++        cright[-right.shape[0]:, -right.shape[1]:] = right
+```
+
+⚠️ **CRITICAL**
+
+* **@@ ハンクヘッダに行番号必須**
+* `@@ -start,count +start,count @@` の形式を守ること
+
+---
+
+## 6. 実行方式と環境
+
+* **評価環境**：固定化された Docker イメージ上で実行
+* **推論制御**：`generator.*` で温度やトークン数を調整
+* **fc\_enabled: true** で **統一 diff を強制**
+
+---
+
+## 7. クイックスタート
+
+### 依存関係
+
+```bash
+./myenv/bin/pip install fastapi "uvicorn[standard]" swebench
+```
+
+### API サーバー起動
+
+```bash
+nohup ./myenv/bin/python scripts/server/swebench_server.py \
+  --host 0.0.0.0 --port 8000 \
+  >/tmp/swebench_server.out 2>&1 & disown
+```
+
+### ジョブ送信例
+
+```bash
+PATCH_FILE=patch.diff
+INSTANCE_ID=astropy__astropy-12907
+curl -s -H "Content-Type: application/json" \
+     -H "X-API-Key: $SWE_API_KEY" \
+     -d @<(jq -n --arg iid "$INSTANCE_ID" --arg patch "$(cat "$PATCH_FILE")" \
+       '{instance_id:$iid, patch_diff:$patch, namespace:"swebench", tag:"latest", model_name_or_path:"nejumi-api"}') \
+     http://127.0.0.1:8000/v1/jobs
+```
+
+---
+
+## 8. コンフィグ主要項目
+
+```yaml
+swebench:
+  artifacts_path: llm-leaderboard/nejumi-leaderboard4/swebench_verified_official:production
+  dataset_dir: swebench_verified_official
+  max_samples: 80
+  max_tokens: 2048
+  max_workers: 4
+  evaluation_method: docker
+  prebuild_images: true
+  fc_enabled: true
+  api_server:
+    enabled: false
+```
+
+---
+
+## 9. オリジナル SWE-Bench からの拡張
+
+* **ハンクヘッダ拡張**
+
+  * ハンクヘッダの `pre_len` / `post_len` を **ctx\*2（既定 ctx=5）だけ増加**
+  * 実際に本文へ文脈行を差し込むわけではなく、**行数を増やすことで適用許容度を拡張**
+  * さらに `git apply` 失敗時は **`patch --fuzz=10` / `--fuzz=20`** を段階的に試行
+
+* **Minimal patch 抽出**
+
+  * 余計な文や無関係な差分を除去し、ヘッダの行番号も再計算
+  * テスト合格に必要最小限の変更に絞る
+
+* **CRITICAL 注意文の付加**
+
+  * @@ ハンクヘッダの行番号必須を明示し、出力の安定性を担保
+
+---
+
+## 10. ベストプラクティス
+
+* **diff のみを出力**（説明テキスト混入禁止）
+* **@@ ヘッダ行番号必須**
+* **Minimal patch 原則**
+* `fc_enabled: true` を有効化
+
+---
+
+## 11. FAQ
+
+* **Q. Resolved 判定は？**
+  → 生成パッチ適用後に **全テストが合格**すれば Resolved。
+
+* **Q. なぜヘッダ拡張？**
+  → 軽微なズレや空白差分でも `git apply` が通るようにするため。
+  → 本文行の挿入ではなく **ヘッダの行数だけを増やす**。
+
+* **Q. fuzz はいつ使う？**
+  → `git apply` が失敗したときに `patch --fuzz=10,20` を順に試行。

--- a/scripts/evaluator/evaluate_utils/bfcl_pkg/SUPPORTED_MODELS.md
+++ b/scripts/evaluator/evaluate_utils/bfcl_pkg/SUPPORTED_MODELS.md
@@ -125,6 +125,8 @@ For model names containing `{...}`, multiple versions are available. For example
 | xLAM-2-70b-fc-r                                | Function Calling | Self-hosted 💻 | Salesforce/Llama-xLAM-2-70b-fc-r                            |
 | xLAM-2-8b-fc-r                                 | Function Calling | Self-hosted 💻 | Salesforce/Llama-xLAM-2-8b-fc-r                             |
 | Upstage (Generic Handler)                      | Function Calling | Upstage        | upstage-FC                                                  |
+| PLaMo-2.0-Prime                                | Function Calling | Preferred AI   | PLaMo-2.0-Prime-FC                                         |
+| PLaMo-2.0-Prime                                | Prompt           | Preferred AI   | PLaMo-2.0-Prime                                            |
 
 | **🆕 Generic OSS Handler (Nejumi Leaderboard)** | **Auto-Detect**     | **Self-hosted 💻** | **oss_handler**                                              |
 

--- a/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/constants/model_config.py
+++ b/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/constants/model_config.py
@@ -25,6 +25,8 @@ from ..model_handler.api_inference.openai_completion import (
 )
 from ..model_handler.api_inference.openai_response import OpenAIResponsesHandler
 from ..model_handler.api_inference.openrouter import OpenRouterHandler
+from ..model_handler.api_inference.plamo import PLaMoAPIHandler
+from ..model_handler.openai_compatible_handler import OpenAICompatibleHandler
 from ..model_handler.api_inference.qwen import (
     QwenAgentNoThinkHandler,
     QwenAgentThinkHandler,
@@ -174,6 +176,18 @@ api_inference_model_map = {
         model_name="DeepSeek-V3-0324",
         display_name="DeepSeek-V3-0324 (FC)",
         url="https://api-docs.deepseek.com/news/news250325",
+        org="DeepSeek",
+        license="DeepSeek License",
+        model_handler=DeepSeekAPIHandler,
+        input_price=None,
+        output_price=None,
+        is_fc_model=True,
+        underscore_to_dot=True,
+    ),
+    "DeepSeek-V3.1-FC": ModelConfig(
+        model_name="DeepSeek-V3.1",
+        display_name="DeepSeek-V3.1 (FC)",
+        url="https://api-docs.deepseek.com/",
         org="DeepSeek",
         license="DeepSeek License",
         model_handler=DeepSeekAPIHandler,
@@ -1198,6 +1212,30 @@ api_inference_model_map = {
         license="MIT",
         model_handler=LingAPIHandler,
         input_price=None,
+        output_price=None,
+        is_fc_model=False,
+        underscore_to_dot=False,
+    ),
+    "PLaMo-2.0-Prime-FC": ModelConfig(
+        model_name="PLaMo-2.0-Prime-FC",
+        display_name="PLaMo-2.0-Prime (FC)",
+        url="https://api.platform.preferredai.jp/docs",
+        org="Preferred AI",
+        license="Proprietary",
+        model_handler=PLaMoAPIHandler,
+        input_price=None,  # Add pricing information if available
+        output_price=None,
+        is_fc_model=True,
+        underscore_to_dot=False,
+    ),
+    "PLaMo-2.0-Prime": ModelConfig(
+        model_name="PLaMo-2.0-Prime",
+        display_name="PLaMo-2.0-Prime (Prompt)",
+        url="https://api.platform.preferredai.jp/docs",
+        org="Preferred AI",
+        license="Proprietary",
+        model_handler=PLaMoAPIHandler,
+        input_price=None,  # Add pricing information if available
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,

--- a/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/constants/supported_models.py
+++ b/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/constants/supported_models.py
@@ -17,6 +17,7 @@ SUPPORTED_MODELS = [
     "DeepSeek-R1-0528",
     "DeepSeek-R1-0528-FC",
     "DeepSeek-V3-0324-FC",
+    "DeepSeek-V3.1-FC",
     "gpt-4.5-preview-2025-02-27",
     "gpt-4.5-preview-2025-02-27-FC",
     "gpt-4.1-2025-04-14-FC",

--- a/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/model_handler/api_inference/plamo.py
+++ b/scripts/evaluator/evaluate_utils/bfcl_pkg/bfcl/model_handler/api_inference/plamo.py
@@ -1,0 +1,465 @@
+import json
+import os
+import time
+from typing import Any, Optional
+
+from .openai_completion import OpenAICompletionsHandler
+from ..model_style import ModelStyle
+from ..utils import (
+    combine_consecutive_user_prompts,
+    func_doc_language_specific_pre_processing,
+    retry_with_backoff,
+    system_prompt_pre_processing_chat_model,
+)
+from openai import OpenAI, RateLimitError
+from overrides import override
+
+
+class PLaMoAPIHandler(OpenAICompletionsHandler):
+    def __init__(self, model_name, temperature) -> None:
+        super().__init__(model_name, temperature)
+        self.model_style = ModelStyle.OpenAI_Completions
+        
+        # PLaMo API設定
+        base_url = "https://api.platform.preferredai.jp/v1"
+        api_key = os.getenv("OPENAI_COMPATIBLE_API_KEY")  # 統一された環境変数名を使用
+        
+        if not api_key:
+            raise ValueError(
+                "OPENAI_COMPATIBLE_API_KEY environment variable is required for PLaMo API. "
+                "Please set your PLaMo API key in the environment."
+            )
+            
+        self.client = OpenAI(
+            base_url=base_url,
+            api_key=api_key
+        )
+
+    @retry_with_backoff(error_type=[RateLimitError, json.JSONDecodeError])
+    def generate_with_backoff(self, **kwargs):
+        start_time = time.time()
+        
+        # PLaMoのサポートパラメータのみを使用
+        plamo_supported_params = {
+            "model", "messages", "max_tokens", "temperature", "top_p", 
+            "tools", "tool_choice", "n", "stop", "stream"
+        }
+        
+        # サポートされていないパラメータを除去
+        filtered_kwargs = {k: v for k, v in kwargs.items() if k in plamo_supported_params}
+        
+        # PLaMo固有の調整
+        if "max_tokens" in filtered_kwargs:
+            # PLaMoの最大出力トークン数は4096
+            filtered_kwargs["max_tokens"] = min(4096, filtered_kwargs.get("max_tokens", 4096))
+        
+        # PLaMoのデフォルト値を設定
+        if "temperature" not in filtered_kwargs:
+            filtered_kwargs["temperature"] = 0.1
+        if "top_p" not in filtered_kwargs:
+            filtered_kwargs["top_p"] = 0.9
+        
+        # 詳細なデバッグログ
+        print(f"[PLaMo DEBUG] ===== API REQUEST DEBUG =====")
+        print(f"[PLaMo DEBUG] Params: {list(filtered_kwargs.keys())}")
+        print(f"[PLaMo DEBUG] Model: {filtered_kwargs.get('model')}")
+
+        # メッセージを正規化（dict以外のオブジェクトも受容）
+        if "messages" in filtered_kwargs and filtered_kwargs["messages"]:
+            normalized_messages = []
+            for m in filtered_kwargs["messages"]:
+                if isinstance(m, dict):
+                    normalized_messages.append(m)
+                else:
+                    # OpenAI SDKのChatCompletionMessageなどをdictへ変換
+                    role = getattr(m, "role", None)
+                    content = getattr(m, "content", None)
+                    tool_calls = getattr(m, "tool_calls", None)
+                    as_dict = {}
+                    if role is not None:
+                        as_dict["role"] = role
+                    if content is not None:
+                        as_dict["content"] = content if isinstance(content, str) else str(content)
+                    if tool_calls:
+                        tc_list = []
+                        for tc in tool_calls:
+                            tc_id = getattr(tc, "id", None)
+                            func = getattr(tc, "function", None)
+                            func_name = getattr(func, "name", None) if func is not None else None
+                            func_args = getattr(func, "arguments", None) if func is not None else None
+                            tc_item = {
+                                "type": "function",
+                                "function": {"name": func_name, "arguments": func_args},
+                            }
+                            if tc_id is not None:
+                                tc_item["id"] = tc_id
+                            tc_list.append(tc_item)
+                        as_dict["tool_calls"] = tc_list
+                    normalized_messages.append(as_dict)
+
+            filtered_kwargs["messages"] = normalized_messages
+
+        print(f"[PLaMo DEBUG] Messages count: {len(filtered_kwargs.get('messages', []))}")
+        print(f"[PLaMo DEBUG] Max tokens: {filtered_kwargs.get('max_tokens')}")
+        print(f"[PLaMo DEBUG] Temperature: {filtered_kwargs.get('temperature')}")
+        print(f"[PLaMo DEBUG] Top-p: {filtered_kwargs.get('top_p')}")
+        
+        if "tools" in filtered_kwargs:
+            tools = filtered_kwargs["tools"]
+            print(f"[PLaMo DEBUG] Tools count: {len(tools)}")
+            for i, tool in enumerate(tools):
+                print(f"[PLaMo DEBUG] Tool {i}: {tool.get('function', {}).get('name', 'N/A')}")
+                
+        if "tool_choice" in filtered_kwargs:
+            print(f"[PLaMo DEBUG] Tool choice: {filtered_kwargs['tool_choice']}")
+        else:
+            print(f"[PLaMo DEBUG] Tool choice: None (auto)")
+            
+        # メッセージ内容もログ出力
+        messages = filtered_kwargs.get('messages', [])
+        for i, msg in enumerate(messages):
+            if isinstance(msg, dict):
+                role = msg.get('role', 'unknown')
+                raw_content = msg.get('content', '')
+            else:
+                role = getattr(msg, 'role', 'unknown')
+                raw_content = getattr(msg, 'content', '')
+            content_str = str(raw_content)
+            content = content_str[:100] + '...' if len(content_str) > 100 else content_str
+            print(f"[PLaMo DEBUG] Message {i} ({role}): {content}")
+            
+        print(f"[PLaMo DEBUG] ===== END DEBUG =====")
+        
+        try:
+            api_response = self.client.chat.completions.create(**filtered_kwargs)
+            end_time = time.time()
+            print(f"[PLaMo DEBUG] API SUCCESS - Response time: {end_time - start_time:.2f}s")
+            return api_response, end_time - start_time
+        except Exception as e:
+            print(f"[PLaMo DEBUG] API FAILED: {e}")
+            print(f"[PLaMo DEBUG] Error type: {type(e)}")
+            raise
+
+    @override
+    def _query_prompting(self, inference_data: dict):
+        """
+        Call the PLaMo API in prompting mode to get the response.
+        Return the response object that can be used to feed into the decode method.
+        """
+        message: list[dict] = inference_data["message"]
+        inference_data["inference_input_log"] = {"message": repr(message)}
+
+        # PLaMoは現在 plamo-2.0-prime のみサポート
+        api_name = "plamo-2.0-prime"
+
+        return self.generate_with_backoff(
+            model=api_name,
+            messages=message,
+            max_tokens=4096,
+            temperature=self.temperature,
+            top_p=0.9,
+        )
+
+    @override
+    def _pre_query_processing_prompting(self, test_entry: dict) -> dict:
+        functions: list = test_entry["function"]
+        test_category: str = test_entry["id"].rsplit("_", 1)[0]
+
+        functions = func_doc_language_specific_pre_processing(functions, test_category)
+        # 先頭ターンにSystemプロンプトを付与（他ハンドラーと同様の流儀）
+        test_entry["question"][0] = system_prompt_pre_processing_chat_model(
+            test_entry["question"][0], functions, test_category
+        )
+        # 連続するuserを結合（必要なモデルで安定化）
+        test_entry["question"][0] = combine_consecutive_user_prompts(test_entry["question"][0])
+
+        # メッセージはここでは空を返し、後段で add_first_turn_message_prompting が埋める
+        return {"message": []}
+
+    @override  
+    def _query_FC(self, inference_data: dict):
+        """
+        Call the PLaMo API in function calling mode to get the response.
+        PLaMoのFunction Calling仕様に特別に対応
+        """
+        message: list[dict] = inference_data["message"]
+        tools = inference_data["tools"]
+        inference_data["inference_input_log"] = {
+            "message": repr(message),
+            "tools": tools,
+        }
+
+        api_name = "plamo-2.0-prime"
+        
+        # PLaMo特別仕様：複数関数の場合はFunction Callingを無効化
+        # PLaMoは複数の関数を同時に処理できない可能性
+        if len(tools) > 1:
+            print(f"[PLaMo WARNING] PLaMo may not support multiple functions ({len(tools)} tools). Fallback to prompt mode.")
+            # 複数関数の場合はプロンプトモードにフォールバック
+            return self._fallback_to_prompt_mode(message, tools)
+        
+        # 単一関数の場合のみFunction Callingを使用
+        tool_choice = None
+        if len(tools) == 1:
+            # PLaMoのサンプルコードに合わせた形式
+            tool_choice = {
+                "type": "function", 
+                "function": {"name": tools[0]["function"]["name"]}
+            }
+
+        kwargs = {
+            "model": api_name,
+            "messages": message,
+            "max_tokens": 4096,
+            "temperature": self.temperature,
+            "top_p": 0.9,
+        }
+        
+        if len(tools) > 0:
+            kwargs["tools"] = tools
+            
+        # PLaMoは単一関数の場合のみtool_choiceを強制指定
+        if tool_choice is not None:
+            kwargs["tool_choice"] = tool_choice
+            
+        print(f"[PLaMo FC] Using tool_choice: {tool_choice}")
+        print(f"[PLaMo FC] Tools: {len(tools)} functions")
+        
+        return self.generate_with_backoff(**kwargs)
+
+    def _fallback_to_prompt_mode(self, message: list[dict], tools: list[dict]):
+        """PLaMoが複数関数をサポートしない場合のプロンプトモードフォールバック（MiniCPMスタイル）"""
+        
+        # MiniCPMスタイルの関数定義生成
+        functions_def = []
+        for tool in tools:
+            func = tool.get("function", {})
+            name = func.get("name", "unknown")
+            description = func.get("description", "")
+            params = func.get("parameters", {}).get("properties", {})
+            
+            # パラメータ情報を含む関数定義
+            param_list = []
+            for param_name, param_info in params.items():
+                param_type = param_info.get("type", "str")
+                param_desc = param_info.get("description", "")
+                param_list.append(f"{param_name}: {param_type} - {param_desc}")
+            
+            required_params = func.get("parameters", {}).get("required", [])
+            func_def = f"def {name}({', '.join(required_params)}):\n    \"\"\"{description}\"\"\""
+            functions_def.append(func_def)
+        
+        # MiniCPMスタイルのシステムプロンプト
+        system_content = f"""# Functions
+Here is a list of functions that you can invoke:
+```python
+{chr(10).join(functions_def)}
+```
+
+# Function Call Rule and Output Format
+- If the user's question can be answered without calling any function, please answer the user's question directly.
+- If the user's question cannot be answered without calling any function, and the user has provided enough information to call functions to solve it, you should call the functions.
+- Use default parameters unless the user has specified otherwise.
+- You should answer in the following format:
+
+<|tool_call_start|>
+```python
+func1(param1="value1", param2="value2")
+func2(param1="value")
+```
+<|tool_call_end|>
+{{answer the user's question directly or ask the user for more information}}"""
+        
+        # メッセージを再構築
+        modified_message = message.copy()
+        if modified_message and modified_message[0].get("role") == "system":
+            modified_message[0]["content"] = system_content + "\n\n" + modified_message[0]["content"]
+        else:
+            modified_message.insert(0, {"role": "system", "content": system_content})
+        
+        # プロンプトモードで実行
+        kwargs = {
+            "model": "plamo-2.0-prime",
+            "messages": modified_message,
+            "max_tokens": 4096,
+            "temperature": self.temperature,
+            "top_p": 0.9,
+        }
+        
+        print(f"[PLaMo FALLBACK] Using MiniCPM-style prompt mode for {len(tools)} functions")
+        return self.generate_with_backoff(**kwargs)
+
+    @override
+    def _pre_query_processing_FC(self, inference_data: dict, test_entry: dict) -> dict:
+        inference_data["message"] = []
+        return inference_data
+    
+    @override
+    def _compile_tools(self, inference_data: dict, test_entry: dict) -> dict:
+        from ..utils import convert_to_tool
+        from ...constants.type_mappings import GORILLA_TO_OPENAPI
+        
+        functions: list = test_entry["function"]
+        test_category: str = test_entry["id"].rsplit("_", 1)[0]
+
+        functions = func_doc_language_specific_pre_processing(functions, test_category)
+        tools = convert_to_tool(functions, GORILLA_TO_OPENAPI, self.model_style)
+        
+        inference_data["tools"] = tools
+        return inference_data
+    
+    @override
+    def _parse_query_response_FC(self, api_response: any) -> dict:
+        """PLaMoのAPI応答をパース（OpenAI標準パターン）"""
+        try:
+            # Function Calling応答を試行
+            model_responses = [
+                {func_call.function.name: func_call.function.arguments}
+                for func_call in api_response.choices[0].message.tool_calls
+            ]
+            tool_call_ids = [
+                func_call.id for func_call in api_response.choices[0].message.tool_calls
+            ]
+            print(f"[PLaMo] Parsed {len(model_responses)} function calls")
+        except Exception as e:
+            # 通常のテキスト応答の場合
+            print(f"[PLaMo] No function calls found, treating as text: {e}")
+            model_responses = api_response.choices[0].message.content
+            tool_call_ids = []
+
+        model_responses_message_for_chat_history = api_response.choices[0].message
+
+        return {
+            "model_responses": model_responses,
+            "model_responses_message_for_chat_history": model_responses_message_for_chat_history,
+            "tool_call_ids": tool_call_ids,
+            "input_token": api_response.usage.prompt_tokens if hasattr(api_response, 'usage') else 0,
+            "output_token": api_response.usage.completion_tokens if hasattr(api_response, 'usage') else 0,
+        }
+        
+    @override
+    def decode_ast(self, result, language="Python"):
+        """PLaMoの応答をデコード（フォールバック対応）"""
+        if "FC" in self.model_name or self.is_fc_model:
+            # Function Calling モードの場合
+            try:
+                # resultが文字列の場合は、MiniCPMスタイルのパースを試行
+                if isinstance(result, str):
+                    print(f"[PLaMo] FC got string result, trying MiniCPM-style parsing: {result[:100]}...")
+                    return self._parse_minicpm_style_output(result, language)
+                
+                # OpenAI標準のFunction Calling応答形式を想定
+                decoded_output = []
+                for invoked_function in result:
+                    name = list(invoked_function.keys())[0]
+                    params = json.loads(invoked_function[name])
+                    decoded_output.append({name: params})
+                return decoded_output
+            except Exception as e:
+                print(f"[PLaMo] FC decode error: {e}")
+                print(f"[PLaMo] Result type: {type(result)}, Content: {str(result)[:200]}...")
+                # 最終フォールバック
+                from ..utils import default_decode_ast_prompting
+                return default_decode_ast_prompting(result, language)
+        else:
+            # Prompt モードの場合
+            from ..utils import default_decode_ast_prompting
+            return default_decode_ast_prompting(result, language)
+
+    def _parse_minicpm_style_output(self, result: str, language="Python"):
+        """MiniCPMスタイルの出力をパース"""
+        import re
+        import ast
+        
+        # <|tool_call_start|>と<|tool_call_end|>の間を抽出
+        pattern = r'<\|tool_call_start\|>(.*?)<\|tool_call_end\|>'
+        matches = re.findall(pattern, result, re.DOTALL)
+        
+        if not matches:
+            print(f"[PLaMo] No tool_call markers found, using default parsing")
+            from ..utils import default_decode_ast_prompting
+            return default_decode_ast_prompting(result, language)
+        
+        # Pythonコードブロックを抽出
+        tool_call_content = matches[0].strip()
+        if tool_call_content.startswith('```python'):
+            tool_call_content = tool_call_content[9:]  # ```python を除去
+        if tool_call_content.endswith('```'):
+            tool_call_content = tool_call_content[:-3]  # ``` を除去
+        
+        try:
+            # ASTパースでfunction callsを抽出
+            parsed = ast.parse(tool_call_content.strip())
+            decoded_output = []
+            
+            for node in ast.walk(parsed):
+                if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                    func_name = node.func.id
+                    func_args = {}
+                    
+                    # キーワード引数を抽出
+                    for keyword in node.keywords:
+                        if isinstance(keyword.value, ast.Constant):
+                            func_args[keyword.arg] = keyword.value.value
+                        elif isinstance(keyword.value, ast.Str):  # Python 3.7以前の互換性
+                            func_args[keyword.arg] = keyword.value.s
+                    
+                    decoded_output.append({func_name: func_args})
+            
+            print(f"[PLaMo] Successfully parsed {len(decoded_output)} function calls")
+            return decoded_output
+            
+        except Exception as e:
+            print(f"[PLaMo] MiniCPM-style parsing failed: {e}")
+            from ..utils import default_decode_ast_prompting
+            return default_decode_ast_prompting(result, language)
+
+    @override
+    def decode_execute(self, result):
+        """PLaMoの実行結果をデコード"""
+        if "FC" in self.model_name or self.is_fc_model:
+            from ..utils import convert_to_function_call
+            return convert_to_function_call(result)
+        else:
+            from ..utils import default_decode_execute_prompting
+            return default_decode_execute_prompting(result)
+
+    # === 重要：Function Callingに必要なメソッド群 ===
+    
+    def add_first_turn_message_FC(
+        self, inference_data: dict, first_turn_message: list[dict]
+    ) -> dict:
+        inference_data["message"].extend(first_turn_message)
+        return inference_data
+
+    def _add_next_turn_user_message_FC(
+        self, inference_data: dict, user_message: list[dict]
+    ) -> dict:
+        inference_data["message"].extend(user_message)
+        return inference_data
+
+    def _add_assistant_message_FC(
+        self, inference_data: dict, model_response_data: dict
+    ) -> dict:
+        inference_data["message"].append(
+            model_response_data["model_responses_message_for_chat_history"]
+        )
+        return inference_data
+
+    def _add_execution_results_FC(
+        self,
+        inference_data: dict,
+        execution_results: list[str],
+        model_response_data: dict,
+    ) -> dict:
+        # PLaMo用の実行結果処理
+        from ..utils import convert_execution_results_to_tool_messages
+        
+        # Add the execution results to the current round result, one at a time
+        for i, execution_result in enumerate(execution_results):
+            tool_message = convert_execution_results_to_tool_messages(
+                execution_result, model_response_data["tool_call_ids"][i]
+            )
+            inference_data["message"].append(tool_message)
+
+        return inference_data

--- a/scripts/evaluator/evaluate_utils/progress_tracker.py
+++ b/scripts/evaluator/evaluate_utils/progress_tracker.py
@@ -1,0 +1,231 @@
+"""
+評価ハーネスの進行状況とターミナル出力の美化機能
+"""
+import time
+import wandb
+from typing import Dict, List, Optional, Any
+import json
+
+
+class EvaluationProgressTracker:
+    """評価進行状況の追跡とシンプルなターミナル出力"""
+    
+    def __init__(self, enabled_benchmarks: List[str]):
+        self.enabled_benchmarks = enabled_benchmarks
+        self.completed_benchmarks = []
+        self.current_benchmark = None
+        self.benchmark_results = {}
+        self.start_time = time.time()
+        
+    def start_tracking(self):
+        """進行状況の追跡を開始"""
+        # ヘッダー表示
+        self._show_header()
+        
+    def start_benchmark(self, benchmark_name: str):
+        """ベンチマーク開始"""
+        self.current_benchmark = benchmark_name
+        self._show_benchmark_start(benchmark_name)
+        
+    def update_benchmark_progress(self, progress_percent: int):
+        """ベンチマーク進行状況を更新"""
+        # シンプル実装では何もしない
+        pass
+            
+    def complete_benchmark(self, benchmark_name: str, results: Optional[Dict[str, Any]] = None):
+        """ベンチマーク完了"""
+        self.completed_benchmarks.append(benchmark_name)
+        
+        if results:
+            self.benchmark_results[benchmark_name] = results
+            
+        # 結果表示
+        self._show_benchmark_completion(benchmark_name, results)
+        
+    def show_leaderboard_table(self, benchmark_name: str, wandb_run: Optional[Any] = None):
+        """W&Bからリーダーボードテーブルを取得して表示"""
+        try:
+            if wandb_run is None:
+                wandb_run = wandb.run
+                
+            if wandb_run is None:
+                print(f"⚠️  W&B run not available for {benchmark_name}")
+                return
+                
+            # W&Bからテーブルを取得
+            table_key = f"{benchmark_name}_leaderboard_table"
+            
+            # W&B APIでテーブルを取得
+            api = wandb.Api()
+            run = api.run(f"{wandb_run.entity}/{wandb_run.project}/{wandb_run.id}")
+            
+            # ログからテーブルデータを探す
+            for log_entry in run.scan_history(keys=[table_key]):
+                if table_key in log_entry:
+                    table_data = log_entry[table_key]
+                    self._render_leaderboard_table(benchmark_name, table_data)
+                    break
+            else:
+                print(f"⚠️  No leaderboard table found for {benchmark_name}")
+                
+        except Exception as e:
+            print(f"❌ Error displaying leaderboard for {benchmark_name}: {e}")
+            
+    def _render_leaderboard_table(self, benchmark_name: str, table_data: Any):
+        """リーダーボードテーブルをシンプル形式で表示"""
+        try:
+            if hasattr(table_data, 'data'):
+                # W&B Tableオブジェクトの場合
+                columns = table_data.columns
+                data = table_data.data
+            elif isinstance(table_data, dict):
+                # 辞書形式の場合
+                columns = table_data.get('columns', [])
+                data = table_data.get('data', [])
+            else:
+                print(f"⚠️  Unknown table format for {benchmark_name}")
+                return
+                
+            print(f"\n{'='*80}")
+            print(f"🏆 {benchmark_name.upper()} LEADERBOARD")
+            print(f"{'='*80}")
+            
+            # ヘッダーを表示
+            header = " | ".join([f"{col:>12}" for col in columns])
+            print(header)
+            print("-" * len(header))
+            
+            # データを表示（上位10件のみ）
+            for i, row in enumerate(data[:10]):
+                row_str = " | ".join([f"{str(cell):>12}" for cell in row])
+                rank_indicator = "🥇" if i == 0 else "🥈" if i == 1 else "🥉" if i == 2 else f"{i+1:2d}"
+                print(f"{rank_indicator} {row_str}")
+                
+            print(f"{'='*80}\n")
+            
+        except Exception as e:
+            print(f"❌ Error rendering table for {benchmark_name}: {e}")
+            
+    def _show_header(self):
+        """ヘッダー表示"""
+        print("\n" + "="*80)
+        print("🚀 LLM EVALUATION HARNESS")
+        print("="*80)
+        print(f"📊 Total Benchmarks: {len(self.enabled_benchmarks)}")
+        print(f"⏰ Started: {time.strftime('%Y-%m-%d %H:%M:%S')}")
+        
+        enabled_list = ", ".join(self.enabled_benchmarks)
+        print(f"🎯 Enabled: {enabled_list}")
+        print("="*80 + "\n")
+        
+    def _show_benchmark_start(self, benchmark_name: str):
+        """ベンチマーク開始の表示"""
+        emoji = self._get_benchmark_emoji(benchmark_name)
+        progress = f"{len(self.completed_benchmarks)+1}/{len(self.enabled_benchmarks)}"
+        
+        print(f"\n{'='*60}")
+        print(f"🚀 [{progress}] STARTING {emoji} {benchmark_name.upper()}")
+        print(f"{'='*60}")
+        
+    def _show_benchmark_completion(self, benchmark_name: str, results: Optional[Dict[str, Any]]):
+        """ベンチマーク完了の表示"""
+        elapsed = time.time() - self.start_time
+        
+        print(f"\n{'='*60}")
+        print(f"✅ {benchmark_name.upper()} COMPLETED")
+        print(f"{'='*60}")
+        print(f"⏱️  Elapsed: {elapsed:.1f}s")
+        
+        if results:
+            print("📊 Key Metrics:")
+            # 主要メトリクスを表示
+            for key, value in list(results.items())[:5]:  # 最初の5つのメトリクス
+                if isinstance(value, (int, float)):
+                    print(f"   {key}: {value:.3f}")
+                    
+        remaining = len(self.enabled_benchmarks) - len(self.completed_benchmarks)
+        print(f"📈 Progress: {len(self.completed_benchmarks)}/{len(self.enabled_benchmarks)} ({remaining} remaining)")
+        print(f"{'='*60}\n")
+        
+    def finish_tracking(self):
+        """追跡終了"""            
+        total_elapsed = time.time() - self.start_time
+        
+        # 最終サマリー
+        print("\n" + "="*80)
+        print("🎉 EVALUATION COMPLETED!")
+        print("="*80)
+        print(f"⏱️  Total Time: {total_elapsed:.1f}s")
+        print(f"✅ Completed: {len(self.completed_benchmarks)}/{len(self.enabled_benchmarks)}")
+        
+        if self.benchmark_results:
+            print("\n📊 Final Results Summary:")
+            for benchmark, results in self.benchmark_results.items():
+                if results and isinstance(results, dict):
+                    # 最初のメトリクスを表示
+                    first_metric = next(iter(results.items()))
+                    if isinstance(first_metric[1], (int, float)):
+                        print(f"  {benchmark}: {first_metric[0]}={first_metric[1]:.3f}")
+                        
+        print("="*80)
+
+    def _get_benchmark_emoji(self, benchmark_name: str) -> str:
+        """ベンチマーク名からシード固定のランダム絵文字を選択"""
+        import hashlib
+        
+        # 評価関連の絵文字リスト
+        emojis = [
+            '🎯', '🔧', '🐛', '📊', '🛡️', '✅', '🧠', '👁️', 
+            '🎲', '📝', '🌸', '🔢', '💻', '🤔', '📖', '💬',
+            '📄', '🌐', '❓', '👀', '📏', '⚡', '🚀', '💡',
+            '🔍', '⭐', '🎪', '🎨', '🎵', '🎭', '🎬', '🎮'
+        ]
+        
+        # ベンチマーク名をハッシュ化してシードとして使用
+        hash_value = hashlib.md5(benchmark_name.encode()).hexdigest()
+        # ハッシュの最初の8文字を16進数として解釈し、絵文字インデックスを決定
+        seed = int(hash_value[:8], 16)
+        emoji_index = seed % len(emojis)
+        
+        return emojis[emoji_index]
+
+
+# グローバルトラッカーインスタンス
+_global_tracker: Optional[EvaluationProgressTracker] = None
+
+
+def get_progress_tracker() -> Optional[EvaluationProgressTracker]:
+    """グローバルプログレストラッカーを取得"""
+    return _global_tracker
+
+
+def initialize_progress_tracker(enabled_benchmarks: List[str]) -> EvaluationProgressTracker:
+    """プログレストラッカーを初期化"""
+    global _global_tracker
+    _global_tracker = EvaluationProgressTracker(enabled_benchmarks)
+    return _global_tracker
+
+
+def start_benchmark_tracking(benchmark_name: str):
+    """ベンチマーク追跡開始"""
+    if _global_tracker:
+        _global_tracker.start_benchmark(benchmark_name)
+
+
+def complete_benchmark_tracking(benchmark_name: str, results: Optional[Dict[str, Any]] = None):
+    """ベンチマーク追跡完了"""
+    if _global_tracker:
+        _global_tracker.complete_benchmark(benchmark_name, results)
+        _global_tracker.show_leaderboard_table(benchmark_name)
+
+
+def update_benchmark_progress(progress_percent: int):
+    """ベンチマーク進行状況更新"""
+    if _global_tracker:
+        _global_tracker.update_benchmark_progress(progress_percent)
+
+
+def finish_progress_tracking():
+    """プログレス追跡終了"""
+    if _global_tracker:
+        _global_tracker.finish_tracking()

--- a/scripts/evaluator/evaluate_utils/validation_helpers.py
+++ b/scripts/evaluator/evaluate_utils/validation_helpers.py
@@ -1,0 +1,189 @@
+"""
+YAML設定のトークン配分バリデーション機能
+
+reasoning機能使用時に出力用トークンが十分に確保されているかをチェックします。
+"""
+import warnings
+from typing import Dict, Any, Optional, Tuple
+from omegaconf import DictConfig
+
+
+def get_reasoning_tokens(cfg: DictConfig) -> Optional[int]:
+    """設定からreasoning用のトークン数を取得"""
+    try:
+        # generator.extra_body.reasoning.max_tokens を確認
+        if hasattr(cfg, 'generator') and hasattr(cfg.generator, 'extra_body'):
+            extra_body = cfg.generator.extra_body
+            if hasattr(extra_body, 'reasoning') and hasattr(extra_body.reasoning, 'max_tokens'):
+                return int(extra_body.reasoning.max_tokens)
+    except (AttributeError, ValueError, TypeError):
+        pass
+    
+    return None
+
+
+def get_max_output_tokens(cfg: DictConfig, benchmark_name: str) -> Optional[int]:
+    """ベンチマーク用の最大出力トークン数を取得"""
+    try:
+        # ベンチマーク固有の設定を確認
+        benchmark_cfg = getattr(cfg, benchmark_name, None)
+        if benchmark_cfg is not None:
+            # 各ベンチマークの設定パターンを確認
+            patterns = [
+                'max_tokens',
+                'max_new_token', 
+                'max_completion_tokens',
+                'max_output_tokens'
+            ]
+            
+            for pattern in patterns:
+                if hasattr(benchmark_cfg, pattern):
+                    value = getattr(benchmark_cfg, pattern)
+                    if value is not None:
+                        return int(value)
+            
+            # generator_config.max_tokensも確認
+            if hasattr(benchmark_cfg, 'generator_config'):
+                gen_cfg = benchmark_cfg.generator_config
+                if hasattr(gen_cfg, 'max_tokens'):
+                    return int(gen_cfg.max_tokens)
+        
+        # フォールバック: generator.max_tokens
+        if hasattr(cfg, 'generator') and hasattr(cfg.generator, 'max_tokens'):
+            return int(cfg.generator.max_tokens)
+            
+    except (AttributeError, ValueError, TypeError):
+        pass
+    
+    return None
+
+
+def check_token_allocation(cfg: DictConfig, benchmark_name: str) -> Tuple[bool, str]:
+    """
+    トークン配分をチェックして、reasoning後に出力用トークンが確保されているかを確認
+    
+    Returns:
+        (is_valid, message): バリデーション結果とメッセージ
+    """
+    reasoning_tokens = get_reasoning_tokens(cfg)
+    max_output_tokens = get_max_output_tokens(cfg, benchmark_name)
+    
+    # 最大出力トークンが取得できない場合は警告
+    if max_output_tokens is None:
+        return False, f"⚠️  {benchmark_name}: 最大出力トークン数が設定されていません"
+    
+    # reasoning機能が使用されていない場合
+    if reasoning_tokens is None:
+        # reasoning未使用時は、トークン数が0以上であれば十分（択一問題など1トークンでもOK）
+        if max_output_tokens > 0:
+            return True, f"✓ {benchmark_name}: Reasoning機能未使用 - トークン数OK ({max_output_tokens})"
+        else:
+            return False, f"❌ {benchmark_name}: 最大出力トークンが0以下です ({max_output_tokens})"
+    
+    # reasoning機能が使用されている場合
+    # 実際の出力用トークン = 最大出力トークン - reasoning用トークン
+    available_output_tokens = max_output_tokens - reasoning_tokens
+    
+    if available_output_tokens <= 0:
+        return False, (
+            f"❌ {benchmark_name}: 出力用トークンが不足しています\n"
+            f"   最大出力トークン: {max_output_tokens}\n"
+            f"   Reasoning用トークン: {reasoning_tokens}\n"
+            f"   出力用残りトークン: {available_output_tokens} (≤ 0)"
+        )
+    elif available_output_tokens < 512:  # reasoning使用時は512以上推奨
+        return False, (
+            f"⚠️  {benchmark_name}: Reasoning使用時の出力用トークンが少ないです\n"
+            f"   最大出力トークン: {max_output_tokens}\n"
+            f"   Reasoning用トークン: {reasoning_tokens}\n"
+            f"   出力用残りトークン: {available_output_tokens} (< 512推奨)"
+        )
+    else:
+        return True, (
+            f"✓ {benchmark_name}: トークン配分OK\n"
+            f"   最大出力トークン: {max_output_tokens}\n"
+            f"   Reasoning用トークン: {reasoning_tokens}\n"
+            f"   出力用残りトークン: {available_output_tokens}"
+        )
+
+
+def pre_evaluation_check(cfg: DictConfig, benchmark_name: str) -> bool:
+    """
+    評価実行前のトークン配分チェック
+    
+    Args:
+        cfg: OmegaConf設定オブジェクト
+        benchmark_name: ベンチマーク名 (mtbench, bfcl, swebench等)
+    
+    Returns:
+        bool: 評価を続行して良いかどうか
+    """
+    is_valid, message = check_token_allocation(cfg, benchmark_name)
+    
+    print("=" * 60)
+    print("🔍 トークン配分チェック")
+    print("=" * 60)
+    print(message)
+    print("=" * 60)
+    
+    if not is_valid:
+        print("\n💡 推奨対応:")
+        reasoning_tokens = get_reasoning_tokens(cfg)
+        if reasoning_tokens:
+            print(f"   1. reasoning.max_tokensを{reasoning_tokens}から削減")
+            print(f"   2. 各ベンチマークのmax_tokensを増加")
+            print(f"   3. 一時的にreasoning機能を無効化")
+        print("\n⚠️  このまま評価を続行すると、空白回答により不当に低いスコアになる可能性があります")
+        
+        # 強制終了はせず、警告のみ表示
+        response = input("\n続行しますか？ (y/N): ").strip().lower()
+        return response in ['y', 'yes']
+    
+    return True
+
+
+def validate_all_benchmarks(cfg: DictConfig) -> Dict[str, Tuple[bool, str]]:
+    """
+    すべてのベンチマークのトークン配分をチェック
+    
+    Returns:
+        Dict[benchmark_name, (is_valid, message)]
+    """
+    # 主要なベンチマーク一覧
+    benchmarks = [
+        'mtbench', 'bfcl', 'swebench', 'jbbq', 'toxicity', 
+        'jtruthfulqa', 'hle', 'hallulens', 'arc_agi', 'm_ifeval', 'jaster'
+    ]
+    
+    results = {}
+    for benchmark in benchmarks:
+        # 実際に設定されているベンチマークのみチェック
+        if hasattr(cfg, benchmark):
+            results[benchmark] = check_token_allocation(cfg, benchmark)
+    
+    return results
+
+
+if __name__ == "__main__":
+    # デバッグ用：設定ファイルを直接テスト
+    from omegaconf import OmegaConf
+    import sys
+    
+    if len(sys.argv) > 1:
+        config_path = sys.argv[1]
+        try:
+            cfg = OmegaConf.load(config_path)
+            print(f"設定ファイル: {config_path}")
+            results = validate_all_benchmarks(cfg)
+            
+            print("\n" + "=" * 60)
+            print("📊 全ベンチマーク トークン配分チェック結果")
+            print("=" * 60)
+            
+            for benchmark, (is_valid, message) in results.items():
+                print(f"\n{message}")
+                
+        except Exception as e:
+            print(f"エラー: {e}")
+    else:
+        print("使用方法: python validation_helpers.py <config_file.yaml>")

--- a/scripts/evaluator/mtbench.py
+++ b/scripts/evaluator/mtbench.py
@@ -267,8 +267,19 @@ async def async_evaluate():
 
     # 1. モデル回答の生成 (修正済み関数を呼び出す)
     print(f"2. モデル回答タスクを生成中... (質問数: {len(questions)})")
-    # mtbenchのgenerator_configを取得
+    # mtbenchのgenerator_configを取得（max_new_tokenとgenerator_config.max_tokensの両方に対応）
     default_generator_config = cfg.mtbench.get("generator_config", {})
+    
+    # max_new_tokenが設定されていて、generator_configにmax_tokensが設定されていない場合はmax_new_tokenを使用
+    if hasattr(cfg.mtbench, 'max_new_token') and cfg.mtbench.max_new_token and 'max_tokens' not in default_generator_config:
+        default_generator_config['max_tokens'] = cfg.mtbench.max_new_token
+    # generator_configにmax_tokensが設定されていない場合のフォールバック処理
+    elif 'max_tokens' not in default_generator_config:
+        # generator.max_tokensをフォールバックとして使用
+        if hasattr(cfg, 'generator') and hasattr(cfg.generator, 'max_tokens'):
+            default_generator_config['max_tokens'] = cfg.generator.max_tokens
+        else:
+            default_generator_config['max_tokens'] = 1024  # デフォルト値
     # mtbenchのtemperatureオーバーライド設定を取得
     temperature_overrides = cfg.mtbench.get("temperature_override", {}) 
 


### PR DESCRIPTION
- 概要
  - もともと一本化されていた「.env + run_with_compose.sh」実行フローに合わせて README を更新、タクソノミーのテーブルも更新
  - ターミナル出力を見やすく構造化（重要ログの整形・出力順序の統一）
  - 実行時に各ベンチの max_tokens をサニティチェックする機能を追加
  - 実行したモデルの YAML を追加
  - SWE‑Bench ドキュメントの英訳版を追加（`docs/README_swebench.md`）

- 変更点
  - docs: `README.md` を最新フローに整合（.env、モデルYAML、`bash ./run_with_compose.sh <config>.yaml`）
  - docs: `docs/README_swebench.md`（日本語版の英訳）を新規追加
  - scripts: 実行時のログを構造化して出力（可読性向上）
  - scripts: 各ベンチの `max_tokens` を起動時に検証（過大設定の早期検出）
  - configs: 実行したモデルの YAML を追加（例: `config-plamo-2.0-prime.yaml` ほか微修正）

- 移行影響
  - 実行フロー自体は既存どおり（.env + run_with_compose.sh）。README の記述をそれに合わせて明確化

- テスト
  - openai/o3-2025-04-16: high-effort [[W&B Run](https://wandb.ai/llm-leaderboard/nejumi-leaderboard4/runs/f4ih7euv)]