### PR TITLE
JHumanEval抽出の堅牢化と評価設定の見直し（max tokens拡張・Runフラグ追加）

### DIFF
--- a/configs/config-gemini-2.5-pro.yaml
+++ b/configs/config-gemini-2.5-pro.yaml
@@ -1,7 +1,8 @@
 wandb:
   run_name: google/gemini-2.5-pro
 api: google # openai, anthropic, google,..
-batch_size: 32
+batch_size: 4
+inference_interval: 2
 model:
   pretrained_model_name_or_path: gemini-2.5-pro #if you use openai api, put the name of model
   bfcl_model_id: "gemini-2.5-pro-FC" # find id from "llm-leaderboard/scripts/evaluator/evaluate_utils/bfcl_pkg/SUPPORTED_MODELS.md"
@@ -9,7 +10,7 @@ model:
   size_category: api
   size: null
   release_date: 6/17/2025
-  thinking_budget: -1  # Pro models support thinking with budget 128-32768
+  thinking_budget: 32768
   safety_settings:
     - category: "HARM_CATEGORY_HATE_SPEECH"
       threshold: "BLOCK_NONE"
@@ -21,3 +22,47 @@ model:
       threshold: "BLOCK_NONE"
     - category: "HARM_CATEGORY_CIVIC_INTEGRITY"
       threshold: "BLOCK_NONE"
+
+generator: # LLM client default configuration: to be overridden by each benchmark
+  max_tokens: 65000
+
+jaster:
+  override_max_tokens: 65000 # if null, use value defined in task dataset files
+
+jbbq:
+  generator_config:
+    max_tokens: 65000
+
+toxicity:
+  generator_config:
+    max_tokens: 65000
+
+jtruthfulqa:
+  generator_config:
+    max_tokens: 65000
+
+swebench:
+  max_tokens: 65000
+
+mtbench:
+  generator_config:
+    max_tokens: 65000
+
+bfcl:
+  generator_config:
+    max_tokens: 65000
+
+hallulens:
+  generator_config:
+    max_tokens: 65000
+
+hle:
+  generator_config:
+    max_tokens: 65000
+
+arc_agi:
+  max_output_tokens: 65000
+
+m_ifeval:
+  generator_config:
+    max_tokens: 65000

--- a/configs/config-o1-2024-12-17.yaml
+++ b/configs/config-o1-2024-12-17.yaml
@@ -16,3 +16,44 @@ generator:
     summary: "auto"
   temparature: None
 
+jaster:
+  override_max_tokens: 90000 # if null, use value defined in task dataset files
+
+jbbq:
+  generator_config:
+    max_tokens: 90000
+
+toxicity:
+  generator_config:
+    max_tokens: 90000
+
+jtruthfulqa:
+  generator_config:
+    max_tokens: 90000
+
+swebench:
+  max_tokens: 90000
+  fc_enabled: true
+
+mtbench:
+  generator_config:
+    max_tokens: 90000
+
+bfcl:
+  generator_config:
+    max_tokens: 90000
+
+hallulens:
+  generator_config:
+    max_tokens: 90000
+
+hle:
+  generator_config:
+    max_tokens: 90000
+
+arc_agi:
+  max_output_tokens: 90000
+
+m_ifeval:
+  generator_config:
+    max_tokens: 90000


### PR DESCRIPTION
- **背景**: JHumaneval系のコード抽出が出力形式の揺れに弱く、長文出力時の切り捨てが発生。各モデル/ベンチのトークン上限や実行設定も分散していたため統一。この現象はOpenAIのReasoningモデル（oシリーズ、GPT-5）で顕著
- **主な変更**
  - **evaluator**: 多段フォールバック（JP/EN/汎用フェンス→関数定義→生出力）、正規化の廃止、`re`導入。
  - **configs**:
    - Gemini 2.5 Pro: batch/interval調整、thinking_budget=32768、max_tokens=65000に統一（トークン枯渇防止）。
    - o1: 出力/生成上限を概ね90000へ、swebench等の各ベンチ用設定を整理（トークン枯渇防止）。
- **動作確認**
  - JHumaneval系で日本語/英語/未指定フェンスの出力から正しく抽出されることを手元確認。
  - 代表ベンチでエラー無くスコア計算が完了することを確認。
- **レビュー観点**
  - 抽出フォールバックの順序/正規表現の妥当性
  - 各ベンチマークの上限値・`run`フラグの既存運用との整合性
- **チェックリスト**
  - openai/o1-2024-12-17: high-effort [[W&B Run](https://wandb.ai/llm-leaderboard/nejumi-leaderboard4/runs/2rtc9qzn)]